### PR TITLE
Fix FZF initialization logic with proper command grouping

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -100,7 +100,7 @@ _nvm_auto_use
 # ------------------------------------------------------------------------------
 # FZF
 # ------------------------------------------------------------------------------
-eval "$(fzf --zsh 2>/dev/null)" || [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+eval "$(fzf --zsh 2>/dev/null)" || { [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh; }
 export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git'
 export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
 export FZF_ALT_C_COMMAND='fd --type d --hidden --follow --exclude .git'


### PR DESCRIPTION
## Summary
Fixed the FZF initialization fallback logic in `.zshrc` by properly grouping the fallback command with braces to ensure correct shell evaluation order.

## Changes
- Wrapped the fallback FZF initialization command in braces `{ ... }` to create a proper command group
- This ensures that both the file existence check `[ -f ~/.fzf.zsh ]` and the source command are treated as a single unit in the OR expression

## Details
The original logic relied on operator precedence which could lead to unexpected behavior. The `&&` operator has higher precedence than `||`, so the original statement would evaluate as:
```
(eval "$(fzf --zsh 2>/dev/null)") || ([ -f ~/.fzf.zsh ]) && (source ~/.fzf.zsh)
```

This could cause `source ~/.fzf.zsh` to execute even if the eval succeeded. The fix ensures the intended behavior:
```
(eval "$(fzf --zsh 2>/dev/null)") || { [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh; }
```

Now the fallback only executes if the initial eval fails, and the source command only runs if the file exists.

https://claude.ai/code/session_01Bz6gcp7YECAVT4ihwwfYF5