### PR TITLE
Add post-install verification step to installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,32 @@ else
 fi
 echo ""
 
+# Post-install verification
+echo -e "${YELLOW}  Verifying installation...${NC}"
+_fail=0
+
+command -v claude &>/dev/null && \
+    echo -e "${GREEN}  claude-code $(claude --version 2>/dev/null)${NC}" || \
+    { echo -e "${RED}  claude-code not found${NC}"; _fail=1; }
+
+command -v wrangler &>/dev/null && \
+    echo -e "${GREEN}  wrangler $(wrangler --version 2>/dev/null)${NC}" || \
+    { echo -e "${RED}  wrangler not found${NC}"; _fail=1; }
+
+command -v node &>/dev/null && \
+    echo -e "${GREEN}  node $(node --version 2>/dev/null)${NC}" || \
+    { echo -e "${RED}  node not found${NC}"; _fail=1; }
+
+command -v gh &>/dev/null && \
+    echo -e "${GREEN}  gh $(gh --version 2>/dev/null | head -1)${NC}" || \
+    { echo -e "${RED}  gh not found${NC}"; _fail=1; }
+
+if [ "$_fail" -eq 1 ]; then
+    echo ""
+    echo -e "${YELLOW}  Some tools missing. Restart your terminal and re-run failed steps.${NC}"
+fi
+echo ""
+
 # Done
 echo -e "${GREEN}  Installation complete.${NC}"
 echo ""


### PR DESCRIPTION
## Summary
Added a post-install verification phase to the installation script that checks whether all required tools were successfully installed and provides user feedback.

## Key Changes
- Added verification checks for four critical tools: `claude`, `wrangler`, `node`, and `gh`
- Each tool check displays its version if found (in green) or reports it as missing (in red)
- Implemented a failure flag (`_fail`) to track if any tools are missing
- Added a warning message if any tools failed verification, instructing users to restart their terminal and re-run failed steps
- Maintains consistent output formatting with existing installation script styling

## Implementation Details
- Uses `command -v` to check tool availability with output redirected to `/dev/null`
- Extracts and displays version information for each tool using their respective `--version` flags
- For `gh`, uses `head -1` to extract only the first line of version output
- Verification runs after all installation steps but before the final "Installation complete" message
- Provides clear visual feedback using color-coded output (yellow for verification header, green for found tools, red for missing tools)

https://claude.ai/code/session_01MynGdxgakZPci1Za6yweCs