### PR TITLE
Add lazy.nvim plugin manager lock file

### DIFF
--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -1,0 +1,7 @@
+{
+  "catppuccin": { "branch": "main", "commit": "beaf41a30c26fd7d6c386d383155cbd65dd554cd" },
+  "lazy.nvim": { "branch": "stable", "commit": "85c7ff3711b730b4030d03144f6db6375044ae82" },
+  "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
+  "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
+  "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" }
+}


### PR DESCRIPTION
This commit adds the `lazy-lock.json` file to track pinned versions of Neovim plugins managed by lazy.nvim.

## Summary
Introduced a lock file for reproducible plugin dependency management in the Neovim configuration.

## Details
The lock file captures the exact commits for the following plugins:
- **lazy.nvim**: Plugin manager itself
- **catppuccin**: Color scheme
- **nvim-treesitter**: Syntax highlighting and parsing
- **telescope.nvim**: Fuzzy finder
- **plenary.nvim**: Utility library (dependency)

This ensures consistent plugin versions across different environments and makes it easier to track plugin updates over time.

https://claude.ai/code/session_01MGRW4pAzqTwtAE2vztd3VK