### PR TITLE
Refactor NVM lazy loading to use shared initialization function

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -55,33 +55,22 @@ bindkey "\e\e" sudo-command-line
 export NVM_DIR="$HOME/.nvm"
 
 # Lazy load NVM: only initialize when first called
-nvm() {
-    unset -f nvm node npm npx
+_nvm_lazy_init() {
+    unset -f nvm node npm npx claude _nvm_lazy_init
     [ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh"
-    nvm "$@"
 }
-node() {
-    unset -f nvm node npm npx
-    [ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh"
-    node "$@"
-}
-npm() {
-    unset -f nvm node npm npx
-    [ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh"
-    npm "$@"
-}
-npx() {
-    unset -f nvm node npm npx
-    [ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh"
-    npx "$@"
-}
+nvm() { _nvm_lazy_init; nvm "$@"; }
+node() { _nvm_lazy_init; node "$@"; }
+npm() { _nvm_lazy_init; npm "$@"; }
+npx() { _nvm_lazy_init; npx "$@"; }
+claude() { _nvm_lazy_init; claude "$@"; }
 
 # Auto-switch Node version when entering a directory with .nvmrc
 _nvm_auto_use() {
     if [ -f ".nvmrc" ]; then
         # If NVM_BIN is empty, NVM hasn't been fully loaded yet
         if [ -z "$NVM_BIN" ]; then
-            unset -f nvm node npm npx 2>/dev/null
+            unset -f nvm node npm npx claude _nvm_lazy_init 2>/dev/null
             [ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh"
         fi
         local nvmrc_node_version=$(cat .nvmrc)


### PR DESCRIPTION
## Summary
Refactored the NVM lazy loading implementation to eliminate code duplication by consolidating the initialization logic into a single `_nvm_lazy_init()` function that is called by all NVM-related command wrappers.

## Key Changes
- Created a new `_nvm_lazy_init()` function that handles sourcing the NVM script and unsetting all lazy-loaded function wrappers
- Replaced four separate function definitions (`nvm`, `node`, `npm`, `npx`) with concise one-liners that call `_nvm_lazy_init` before delegating to the actual command
- Added `claude` command to the lazy-loading system with the same pattern
- Updated the `_nvm_auto_use()` function to also unset the new `_nvm_lazy_init` function when manually initializing NVM

## Implementation Details
- The refactoring reduces ~25 lines of repetitive code to ~5 lines while maintaining identical functionality
- All lazy-loaded functions now follow a consistent pattern: `command() { _nvm_lazy_init; command "$@"; }`
- The `_nvm_lazy_init` function unsets itself along with all command wrappers after sourcing the NVM script, ensuring it only runs once per shell session

https://claude.ai/code/session_01KUcV5HPNXvRzcPjL9yRQJf