### PR TITLE
Add lazy-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # Vim / Neovim
 *.swp
 *.swo
+config/nvim/lazy-lock.json
 
 # Cursor
 .cursor/

--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -1,7 +1,0 @@
-{
-  "catppuccin": { "branch": "main", "commit": "beaf41a30c26fd7d6c386d383155cbd65dd554cd" },
-  "lazy.nvim": { "branch": "stable", "commit": "85c7ff3711b730b4030d03144f6db6375044ae82" },
-  "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
-  "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
-  "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" }
-}


### PR DESCRIPTION
## Summary
This change adds the Neovim lazy plugin manager lockfile to the gitignore, preventing it from being tracked in version control.

## Changes
- Added `config/nvim/lazy-lock.json` to `.gitignore` to exclude the lazy.nvim lockfile from the repository
- Removed the previously committed `lazy-lock.json` file from version control

## Rationale
Lockfiles for package managers are typically generated artifacts that should not be committed to version control. This allows each developer or environment to maintain their own dependency versions while keeping the repository clean and reducing merge conflicts related to dependency updates.

https://claude.ai/code/session_01PmxkSxAkGfQpQL9MHSzwBv