### PR TITLE
docs: add dev quickstart guide

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,99 @@
+# Dev Quickstart
+
+## Install (one command)
+
+```bash
+git clone https://github.com/jamesfdavis/dotfiles.git ~/dotfiles
+cd ~/dotfiles && ./install.sh
+```
+
+This runs five automated steps: Homebrew packages, config symlinks, SSH key generation, Node.js via NVM, and global npm installs (Claude Code + Wrangler).
+
+## Post-install checklist
+
+1. Restart your terminal (or `source ~/.zshrc`)
+2. Register both SSH keys on GitHub — the install script prints them
+   - `~/.ssh/id_ed25519.pub` → **Authentication** key
+   - `~/.ssh/id_ed25519_signing.pub` → **Signing** key
+3. Set up secrets: `cp ~/.extra.example ~/.extra && nvim ~/.extra`
+4. Auth GitHub CLI: `gh auth login`
+
+## What you get
+
+| What | Tool | Key alias |
+|------|------|-----------|
+| Terminal | Ghostty (Catppuccin Mocha) | — |
+| Shell | Zsh + Starship prompt | — |
+| AI agent | Claude Code | `cc` |
+| Editor | Neovim (Telescope, Treesitter) | `v` |
+| Git UI | Lazygit | `lg` |
+| Git | SSH-signed commits, rebase-by-default | `gs` `ga` `gcm` `gp` |
+| Search | ripgrep + fd + fzf | `rg` `fd` `Ctrl+T` |
+| Node | NVM with auto .nvmrc switching | lazy-loaded |
+| Python | uv | `uvv` `uva` |
+| Cloudflare | Wrangler | `wr` `wrd` `wrp` |
+| Smart cd | zoxide | `z <dir>` |
+| Docker | Colima + Docker Compose | `dc` `dcu` `dcd` |
+
+## Workflow
+
+Agent writes code, you steer. Everything runs in the terminal.
+
+Features follow: **Plan → Milestones → Issues → TDD → Implementation**
+
+In Claude Code, use the slash commands:
+
+- `/plan` — research codebase, draft design, get approval
+- `/milestone` — break the plan into milestones with acceptance criteria
+- `/issues` — create GitHub issues from milestones via `gh` CLI
+- `/tdd` — write failing tests first, then implement
+
+## Day-one commands
+
+```bash
+dot           # jump to ~/dotfiles
+cc            # launch Claude Code
+lg            # open lazygit
+v .           # open current dir in neovim
+z <dir>       # smart directory jump
+tre           # pretty tree view (3 levels)
+brewup        # update all Homebrew packages
+cleanup       # remove node_modules, dist, .wrangler, .DS_Store
+genpass       # generate a secure random password
+myip          # show external IP
+serve         # quick Python HTTP server on port 8000
+```
+
+## Git aliases
+
+```bash
+gs            # git status
+ga            # git add
+gcm "msg"     # git commit -m
+gp            # git push
+gl            # git pull
+glog          # git log --graph
+uncommit      # undo last commit (soft reset)
+```
+
+## Docs
+
+Detailed documentation for every tool lives in `~/dotfiles/obsidian/` (14 markdown files). Open it as an Obsidian vault or read them directly.
+
+| File | Covers |
+|------|--------|
+| 00-stack.md | Full stack overview |
+| 01-ghostty-starship.md | Terminal + prompt |
+| 02-claude-code.md | Agent workflow |
+| 03-cloudflare.md | Workers, D1, KV, R2 |
+| 05-git-workflow.md | Git config + signing |
+| 07-neovim.md | Editor keybindings |
+| 08-fzf-ripgrep-fd.md | Search tools |
+| 13-zsh-shell.md | Shell plugins + history |
+
+## Updating
+
+```bash
+cd ~/dotfiles && git pull    # symlinks update instantly
+brewup                       # update Homebrew packages
+```


### PR DESCRIPTION
One-page TLDR for a developer starting with these dotfiles —
covers install, post-install checklist, tool/alias cheat sheet,
workflow commands, and pointers to the full Obsidian docs.

https://claude.ai/code/session_01JEHCGgmpPGEQRpuyejFEwH