### PR TITLE
feat: integrate kickstart.nvim features into neovim config

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -363,6 +363,7 @@ require("lazy").setup({
       local servers = {
         ts_ls = {},
         pyright = {},
+        eslint = {},
       }
 
       -- Ensure servers + tools are installed via Mason

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -197,6 +197,7 @@ require("lazy").setup({
         { "<leader>s", group = "Search", mode = { "n", "v" } },
         { "<leader>t", group = "Toggle" },
         { "<leader>h", group = "Git Hunk", mode = { "n", "v" } },
+        { "<leader>g", group = "Git" },
         { "<leader>x", group = "Diagnostics/Extras" },
       },
     },
@@ -457,6 +458,19 @@ require("lazy").setup({
       })
       vim.cmd.colorscheme("catppuccin-mocha")
     end,
+  },
+
+  -- Side-by-side diff viewer and file history
+  {
+    "sindrets/diffview.nvim",
+    cmd = { "DiffviewOpen", "DiffviewFileHistory", "DiffviewClose" },
+    keys = {
+      { "<leader>gd", "<cmd>DiffviewOpen<CR>", desc = "Diff view (working changes)" },
+      { "<leader>gh", "<cmd>DiffviewFileHistory %<CR>", desc = "File history (current file)" },
+      { "<leader>gH", "<cmd>DiffviewFileHistory<CR>", desc = "File history (repo)" },
+      { "<leader>gc", "<cmd>DiffviewClose<CR>", desc = "Close diff view" },
+    },
+    opts = {},
   },
 
   -- Highlight TODO/FIXME/HACK in comments

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -172,7 +172,7 @@ require("lazy").setup({
   -- Auto-detect indentation
   { "NMAC427/guess-indent.nvim", opts = {} },
 
-  -- Git signs in the gutter
+  -- Git signs in the gutter + hunk actions
   {
     "lewis6991/gitsigns.nvim",
     opts = {
@@ -183,6 +183,32 @@ require("lazy").setup({
         topdelete = { text = "‾" },
         changedelete = { text = "~" },
       },
+      on_attach = function(bufnr)
+        local gs = require("gitsigns")
+        local function bmap(mode, l, r, desc)
+          vim.keymap.set(mode, l, r, { buffer = bufnr, desc = desc })
+        end
+
+        -- Navigation between hunks
+        bmap("n", "]h", function() gs.nav_hunk("next") end, "Next hunk")
+        bmap("n", "[h", function() gs.nav_hunk("prev") end, "Previous hunk")
+
+        -- Hunk actions
+        bmap("n", "<leader>hp", gs.preview_hunk, "Preview hunk")
+        bmap("n", "<leader>hs", gs.stage_hunk, "Stage hunk")
+        bmap("n", "<leader>hu", gs.undo_stage_hunk, "Undo stage hunk")
+        bmap("n", "<leader>hr", gs.reset_hunk, "Reset hunk")
+
+        -- Visual mode stage/reset
+        bmap("v", "<leader>hs", function() gs.stage_hunk({ vim.fn.line("."), vim.fn.line("v") }) end, "Stage selection")
+        bmap("v", "<leader>hr", function() gs.reset_hunk({ vim.fn.line("."), vim.fn.line("v") }) end, "Reset selection")
+
+        -- Buffer-level actions
+        bmap("n", "<leader>hS", gs.stage_buffer, "Stage buffer")
+        bmap("n", "<leader>hR", gs.reset_buffer, "Reset buffer")
+        bmap("n", "<leader>hb", function() gs.blame_line({ full = true }) end, "Blame line")
+        bmap("n", "<leader>hd", gs.diffthis, "Diff against index")
+      end,
     },
   },
 

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -364,6 +364,7 @@ require("lazy").setup({
         ts_ls = {},
         pyright = {},
         eslint = {},
+        svelte = {},
       }
 
       -- Ensure servers + tools are installed via Mason
@@ -533,7 +534,7 @@ require("lazy").setup({
     config = function()
       require("nvim-treesitter.configs").setup({
         ensure_installed = {
-          "javascript", "typescript", "tsx", "json", "yaml", "toml",
+          "javascript", "typescript", "tsx", "svelte", "json", "yaml", "toml",
           "lua", "luadoc", "python", "markdown", "markdown_inline",
           "bash", "html", "css", "diff", "vim", "vimdoc", "query",
         },

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,28 +1,40 @@
--- Neovim configuration - fast edits + git commit authoring
+-- Neovim configuration - kickstart.nvim features + personal customizations
 -- Claude Code is the primary development tool; this adds comfort for direct use.
 
--- ── Options ─────────────────────────────────────────────────────────
+-- ── Nerd Font ─────────────────────────────────────────────────────
+-- Fira Code Nerd Font is installed via Brewfile
+vim.g.have_nerd_font = true
+
+-- ── Leader key ────────────────────────────────────────────────────
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+
+-- ── Options ───────────────────────────────────────────────────────
 
 vim.opt.number = true
 vim.opt.relativenumber = true
 vim.opt.mouse = "a"
-vim.opt.clipboard = "unnamedplus"
+vim.opt.showmode = false
 vim.opt.signcolumn = "yes"
 vim.opt.termguicolors = true
 vim.opt.cursorline = true
-vim.opt.showmode = false
+
+-- Clipboard (scheduled for faster startup)
+vim.schedule(function() vim.opt.clipboard = "unnamedplus" end)
 
 -- Indentation
 vim.opt.tabstop = 2
 vim.opt.shiftwidth = 2
 vim.opt.expandtab = true
 vim.opt.smartindent = true
+vim.opt.breakindent = true
 
 -- Search
 vim.opt.ignorecase = true
 vim.opt.smartcase = true
 vim.opt.hlsearch = true
 vim.opt.incsearch = true
+vim.opt.inccommand = "split" -- live substitution preview
 
 -- Editing
 vim.opt.wrap = true
@@ -33,6 +45,11 @@ vim.opt.swapfile = false
 vim.opt.backup = false
 vim.opt.splitbelow = true
 vim.opt.splitright = true
+vim.opt.confirm = true
+
+-- Whitespace visualization
+vim.opt.list = true
+vim.opt.listchars = { tab = "» ", trail = "·", nbsp = "␣" }
 
 -- Performance
 vim.opt.updatetime = 250
@@ -44,21 +61,37 @@ if vim.fn.executable("rg") == 1 then
   vim.opt.grepformat = "%f:%l:%c:%m,%f:%l:%m"
 end
 
--- Leader key
-vim.g.mapleader = " "
+-- ── Diagnostics ───────────────────────────────────────────────────
 
--- ── Keymaps ─────────────────────────────────────────────────────────
+vim.diagnostic.config({
+  update_in_insert = false,
+  severity_sort = true,
+  float = { border = "rounded", source = "if_many" },
+  underline = { severity = vim.diagnostic.severity.ERROR },
+  virtual_text = true,
+  virtual_lines = false,
+  jump = { float = true },
+})
+
+-- ── Keymaps ───────────────────────────────────────────────────────
 
 local map = vim.keymap.set
+
+-- Clear search highlight
 map("n", "<Esc>", "<cmd>nohlsearch<CR>")
+
+-- Quick save/quit
 map("n", "<leader>w", "<cmd>w<CR>", { desc = "Save" })
 map("n", "<leader>q", "<cmd>q<CR>", { desc = "Quit" })
 
+-- Diagnostics
+map("n", "<leader>xq", vim.diagnostic.setloclist, { desc = "Diagnostic quickfix list" })
+
 -- Split navigation
-map("n", "<C-h>", "<C-w>h")
-map("n", "<C-j>", "<C-w>j")
-map("n", "<C-k>", "<C-w>k")
-map("n", "<C-l>", "<C-w>l")
+map("n", "<C-h>", "<C-w><C-h>", { desc = "Focus left window" })
+map("n", "<C-j>", "<C-w><C-j>", { desc = "Focus lower window" })
+map("n", "<C-k>", "<C-w><C-k>", { desc = "Focus upper window" })
+map("n", "<C-l>", "<C-w><C-l>", { desc = "Focus right window" })
 
 -- Center after jump
 map("n", "<C-d>", "<C-d>zz")
@@ -69,15 +102,26 @@ map("n", "N", "Nzzzv")
 -- Better Y
 map("n", "Y", "y$")
 
+-- Exit terminal mode
+map("t", "<Esc><Esc>", "<C-\\><C-n>", { desc = "Exit terminal mode" })
+
 -- Strip trailing whitespace
-map("n", "<leader>ss", function()
+map("n", "<leader>xw", function()
   local pos = vim.api.nvim_win_get_cursor(0)
   vim.cmd([[%s/\s\+$//e]])
   vim.api.nvim_win_set_cursor(0, pos)
-end, { desc = "Strip whitespace" })
+end, { desc = "Strip trailing whitespace" })
 
--- ── Git commit authoring ────────────────────────────────────────────
+-- ── Autocommands ──────────────────────────────────────────────────
 
+-- Highlight on yank
+vim.api.nvim_create_autocmd("TextYankPost", {
+  desc = "Highlight when yanking text",
+  group = vim.api.nvim_create_augroup("highlight-yank", { clear = true }),
+  callback = function() vim.hl.on_yank() end,
+})
+
+-- Git commit authoring
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "gitcommit",
   callback = function()
@@ -85,15 +129,13 @@ vim.api.nvim_create_autocmd("FileType", {
     vim.opt_local.textwidth = 72
     vim.opt_local.spell = true
     vim.opt_local.colorcolumn = "50,72"
-    -- Start in insert mode on first line if empty
     if vim.fn.line("$") == 1 or vim.fn.getline(1) == "" then
       vim.cmd("startinsert")
     end
   end,
 })
 
--- ── File type settings ──────────────────────────────────────────────
-
+-- File type indentation
 vim.api.nvim_create_autocmd("FileType", {
   pattern = { "javascript", "typescript", "json", "yaml", "toml", "lua" },
   callback = function()
@@ -110,57 +152,362 @@ vim.api.nvim_create_autocmd("FileType", {
   end,
 })
 
--- ── Bootstrap lazy.nvim ─────────────────────────────────────────────
+-- ── Bootstrap lazy.nvim ───────────────────────────────────────────
 
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.uv.fs_stat(lazypath) then
-  vim.fn.system({
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  local out = vim.fn.system({
     "git", "clone", "--filter=blob:none",
     "https://github.com/folke/lazy.nvim.git",
     "--branch=stable", lazypath,
   })
+  if vim.v.shell_error ~= 0 then error("Error cloning lazy.nvim:\n" .. out) end
 end
 vim.opt.rtp:prepend(lazypath)
 
--- ── Plugins ─────────────────────────────────────────────────────────
+-- ── Plugins ───────────────────────────────────────────────────────
 
 require("lazy").setup({
+
+  -- Auto-detect indentation
+  { "NMAC427/guess-indent.nvim", opts = {} },
+
+  -- Git signs in the gutter
+  {
+    "lewis6991/gitsigns.nvim",
+    opts = {
+      signs = {
+        add = { text = "+" },
+        change = { text = "~" },
+        delete = { text = "_" },
+        topdelete = { text = "‾" },
+        changedelete = { text = "~" },
+      },
+    },
+  },
+
+  -- Keybinding discovery
+  {
+    "folke/which-key.nvim",
+    event = "VimEnter",
+    opts = {
+      delay = 0,
+      icons = { mappings = vim.g.have_nerd_font },
+      spec = {
+        { "<leader>s", group = "Search", mode = { "n", "v" } },
+        { "<leader>t", group = "Toggle" },
+        { "<leader>h", group = "Git Hunk", mode = { "n", "v" } },
+        { "<leader>x", group = "Diagnostics/Extras" },
+      },
+    },
+  },
+
+  -- Fuzzy finder
+  {
+    "nvim-telescope/telescope.nvim",
+    event = "VimEnter",
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+      {
+        "nvim-telescope/telescope-fzf-native.nvim",
+        build = "make",
+        cond = function() return vim.fn.executable("make") == 1 end,
+      },
+      { "nvim-telescope/telescope-ui-select.nvim" },
+      { "nvim-tree/nvim-web-devicons", enabled = vim.g.have_nerd_font },
+    },
+    config = function()
+      require("telescope").setup({
+        extensions = {
+          ["ui-select"] = { require("telescope.themes").get_dropdown() },
+        },
+      })
+
+      pcall(require("telescope").load_extension, "fzf")
+      pcall(require("telescope").load_extension, "ui-select")
+
+      local builtin = require("telescope.builtin")
+
+      -- Search keymaps (leader-s prefix)
+      map("n", "<leader>sh", builtin.help_tags, { desc = "Search help" })
+      map("n", "<leader>sk", builtin.keymaps, { desc = "Search keymaps" })
+      map("n", "<leader>sf", builtin.find_files, { desc = "Search files" })
+      map("n", "<leader>ss", builtin.builtin, { desc = "Search select Telescope" })
+      map({ "n", "v" }, "<leader>sw", builtin.grep_string, { desc = "Search current word" })
+      map("n", "<leader>sg", builtin.live_grep, { desc = "Search by grep" })
+      map("n", "<leader>sd", builtin.diagnostics, { desc = "Search diagnostics" })
+      map("n", "<leader>sr", builtin.resume, { desc = "Search resume" })
+      map("n", "<leader>s.", builtin.oldfiles, { desc = "Search recent files" })
+      map("n", "<leader>sc", builtin.commands, { desc = "Search commands" })
+      map("n", "<leader><leader>", builtin.buffers, { desc = "Find buffers" })
+
+      -- LSP-powered Telescope pickers (attached per buffer)
+      vim.api.nvim_create_autocmd("LspAttach", {
+        group = vim.api.nvim_create_augroup("telescope-lsp-attach", { clear = true }),
+        callback = function(event)
+          local buf = event.buf
+          map("n", "grr", builtin.lsp_references, { buffer = buf, desc = "Goto references" })
+          map("n", "gri", builtin.lsp_implementations, { buffer = buf, desc = "Goto implementation" })
+          map("n", "grd", builtin.lsp_definitions, { buffer = buf, desc = "Goto definition" })
+          map("n", "grt", builtin.lsp_type_definitions, { buffer = buf, desc = "Goto type definition" })
+          map("n", "gO", builtin.lsp_document_symbols, { buffer = buf, desc = "Document symbols" })
+          map("n", "gW", builtin.lsp_dynamic_workspace_symbols, { buffer = buf, desc = "Workspace symbols" })
+        end,
+      })
+
+      -- Search in current buffer
+      map("n", "<leader>/", function()
+        builtin.current_buffer_fuzzy_find(require("telescope.themes").get_dropdown({
+          winblend = 10,
+          previewer = false,
+        }))
+      end, { desc = "Fuzzy search current buffer" })
+
+      -- Live grep in open files
+      map("n", "<leader>s/", function()
+        builtin.live_grep({ grep_open_files = true, prompt_title = "Live Grep in Open Files" })
+      end, { desc = "Search in open files" })
+
+      -- Search neovim config files
+      map("n", "<leader>sn", function()
+        builtin.find_files({ cwd = vim.fn.stdpath("config") })
+      end, { desc = "Search neovim files" })
+    end,
+  },
+
+  -- LSP
+  {
+    "neovim/nvim-lspconfig",
+    dependencies = {
+      { "mason-org/mason.nvim", opts = {} },
+      "WhoIsSethDaniel/mason-tool-installer.nvim",
+      { "j-hui/fidget.nvim", opts = {} },
+      "saghen/blink.cmp",
+    },
+    config = function()
+      vim.api.nvim_create_autocmd("LspAttach", {
+        group = vim.api.nvim_create_augroup("lsp-attach", { clear = true }),
+        callback = function(event)
+          local lsp_map = function(keys, func, desc, mode)
+            mode = mode or "n"
+            vim.keymap.set(mode, keys, func, { buffer = event.buf, desc = "LSP: " .. desc })
+          end
+
+          lsp_map("grn", vim.lsp.buf.rename, "Rename")
+          lsp_map("gra", vim.lsp.buf.code_action, "Code action", { "n", "x" })
+          lsp_map("grD", vim.lsp.buf.declaration, "Goto declaration")
+
+          -- Highlight references on cursor hold
+          local client = vim.lsp.get_client_by_id(event.data.client_id)
+          if client and client:supports_method("textDocument/documentHighlight", event.buf) then
+            local highlight_augroup = vim.api.nvim_create_augroup("lsp-highlight", { clear = false })
+            vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
+              buffer = event.buf,
+              group = highlight_augroup,
+              callback = vim.lsp.buf.document_highlight,
+            })
+            vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+              buffer = event.buf,
+              group = highlight_augroup,
+              callback = vim.lsp.buf.clear_references,
+            })
+            vim.api.nvim_create_autocmd("LspDetach", {
+              group = vim.api.nvim_create_augroup("lsp-detach", { clear = true }),
+              callback = function(event2)
+                vim.lsp.buf.clear_references()
+                vim.api.nvim_clear_autocmds({ group = "lsp-highlight", buffer = event2.buf })
+              end,
+            })
+          end
+
+          -- Toggle inlay hints
+          if client and client:supports_method("textDocument/inlayHint", event.buf) then
+            lsp_map("<leader>th", function()
+              vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = event.buf }))
+            end, "Toggle inlay hints")
+          end
+        end,
+      })
+
+      -- Capabilities from blink.cmp
+      local capabilities = require("blink.cmp").get_lsp_capabilities()
+
+      -- Language servers for the stack
+      local servers = {
+        ts_ls = {},
+        pyright = {},
+      }
+
+      -- Ensure servers + tools are installed via Mason
+      local ensure_installed = vim.tbl_keys(servers or {})
+      vim.list_extend(ensure_installed, {
+        "lua_ls",    -- Lua language server
+        "stylua",    -- Lua formatter
+        "prettierd", -- JS/TS formatter
+        "black",     -- Python formatter
+      })
+      require("mason-tool-installer").setup({ ensure_installed = ensure_installed })
+
+      -- Configure and enable servers
+      for name, server in pairs(servers) do
+        server.capabilities = vim.tbl_deep_extend("force", {}, capabilities, server.capabilities or {})
+        vim.lsp.config(name, server)
+        vim.lsp.enable(name)
+      end
+
+      -- Lua LS with Neovim runtime support
+      vim.lsp.config("lua_ls", {
+        capabilities = capabilities,
+        on_init = function(client)
+          if client.workspace_folders then
+            local path = client.workspace_folders[1].name
+            if path ~= vim.fn.stdpath("config")
+              and (vim.uv.fs_stat(path .. "/.luarc.json") or vim.uv.fs_stat(path .. "/.luarc.jsonc"))
+            then
+              return
+            end
+          end
+          client.config.settings.Lua = vim.tbl_deep_extend("force", client.config.settings.Lua, {
+            runtime = { version = "LuaJIT" },
+            workspace = {
+              checkThirdParty = false,
+              library = vim.api.nvim_get_runtime_file("", true),
+            },
+          })
+        end,
+        settings = { Lua = {} },
+      })
+      vim.lsp.enable("lua_ls")
+    end,
+  },
+
+  -- Auto-format on save
+  {
+    "stevearc/conform.nvim",
+    event = { "BufWritePre" },
+    cmd = { "ConformInfo" },
+    keys = {
+      {
+        "<leader>f",
+        function() require("conform").format({ async = true, lsp_format = "fallback" }) end,
+        mode = "",
+        desc = "Format buffer",
+      },
+    },
+    opts = {
+      notify_on_error = false,
+      format_on_save = function(bufnr)
+        local disable_filetypes = { c = true, cpp = true }
+        if disable_filetypes[vim.bo[bufnr].filetype] then return nil end
+        return { timeout_ms = 500, lsp_format = "fallback" }
+      end,
+      formatters_by_ft = {
+        lua = { "stylua" },
+        javascript = { "prettierd", "prettier", stop_after_first = true },
+        typescript = { "prettierd", "prettier", stop_after_first = true },
+        json = { "prettierd", "prettier", stop_after_first = true },
+        yaml = { "prettierd", "prettier", stop_after_first = true },
+        html = { "prettierd", "prettier", stop_after_first = true },
+        css = { "prettierd", "prettier", stop_after_first = true },
+        markdown = { "prettierd", "prettier", stop_after_first = true },
+        python = { "black" },
+      },
+    },
+  },
+
+  -- Autocompletion
+  {
+    "saghen/blink.cmp",
+    event = "VimEnter",
+    version = "1.*",
+    dependencies = {
+      {
+        "L3MON4D3/LuaSnip",
+        version = "2.*",
+        build = (function()
+          if vim.fn.has("win32") == 1 or vim.fn.executable("make") == 0 then return end
+          return "make install_jsregexp"
+        end)(),
+        opts = {},
+      },
+    },
+    ---@module "blink.cmp"
+    ---@type blink.cmp.Config
+    opts = {
+      keymap = { preset = "default" },
+      appearance = { nerd_font_variant = "mono" },
+      completion = {
+        documentation = { auto_show = true, auto_show_delay_ms = 250 },
+      },
+      sources = { default = { "lsp", "path", "snippets" } },
+      snippets = { preset = "luasnip" },
+      fuzzy = { implementation = "lua" },
+      signature = { enabled = true },
+    },
+  },
+
   -- Theme (match Ghostty)
   {
     "catppuccin/nvim",
     name = "catppuccin",
     priority = 1000,
     config = function()
+      require("catppuccin").setup({
+        styles = { comments = {} }, -- no italics
+      })
       vim.cmd.colorscheme("catppuccin-mocha")
     end,
   },
 
-  -- Fuzzy finder
+  -- Highlight TODO/FIXME/HACK in comments
   {
-    "nvim-telescope/telescope.nvim",
-    branch = "0.1.x",
+    "folke/todo-comments.nvim",
+    event = "VimEnter",
     dependencies = { "nvim-lua/plenary.nvim" },
-    keys = {
-      { "<leader>f", "<cmd>Telescope find_files<cr>", desc = "Find files" },
-      { "<leader>g", "<cmd>Telescope live_grep<cr>", desc = "Live grep" },
-      { "<leader>b", "<cmd>Telescope buffers<cr>", desc = "Buffers" },
-      { "<leader>/", "<cmd>Telescope current_buffer_fuzzy_find<cr>", desc = "Search buffer" },
-    },
+    opts = { signs = false },
   },
 
-  -- Syntax highlighting
+  -- Mini modules (textobjects, surround, statusline)
+  {
+    "nvim-mini/mini.nvim",
+    config = function()
+      -- Better around/inside textobjects (va), yinq, ci', etc.)
+      require("mini.ai").setup({ n_lines = 500 })
+
+      -- Add/delete/replace surroundings (saiw), sd', sr)')
+      require("mini.surround").setup()
+
+      -- Statusline
+      local statusline = require("mini.statusline")
+      statusline.setup({ use_icons = vim.g.have_nerd_font })
+      ---@diagnostic disable-next-line: duplicate-set-field
+      statusline.section_location = function() return "%2l:%-2v" end
+    end,
+  },
+
+  -- Syntax highlighting + code navigation
   {
     "nvim-treesitter/nvim-treesitter",
     build = ":TSUpdate",
     config = function()
       require("nvim-treesitter.configs").setup({
         ensure_installed = {
-          "javascript", "typescript", "json", "yaml", "toml",
-          "lua", "python", "markdown", "bash", "html", "css",
+          "javascript", "typescript", "tsx", "json", "yaml", "toml",
+          "lua", "luadoc", "python", "markdown", "markdown_inline",
+          "bash", "html", "css", "diff", "vim", "vimdoc", "query",
         },
         highlight = { enable = true },
         indent = { enable = true },
       })
     end,
   },
-}, { ui = { border = "rounded" } })
+}, {
+  ui = {
+    border = "rounded",
+    icons = vim.g.have_nerd_font and {} or {
+      cmd = "⌘", config = "🛠", event = "📅", ft = "📂",
+      init = "⚙", keys = "🗝", plugin = "🔌", runtime = "💻",
+      require = "🌙", source = "📄", start = "🚀", task = "📌", lazy = "💤 ",
+    },
+  },
+})

--- a/obsidian/07-neovim.md
+++ b/obsidian/07-neovim.md
@@ -205,6 +205,7 @@ LSP provides go-to-definition, references, rename, diagnostics, and more. Server
 |----------|--------|-----------------|
 | JavaScript/TypeScript | ts_ls | Type errors, missing imports, bad references |
 | JavaScript/TypeScript | eslint | Lint rules, unused vars, React hooks, style |
+| Svelte | svelte | `.svelte` files — script, template, and style blocks |
 | Python | pyright | Type errors, missing imports |
 | Lua | lua_ls (Neovim-aware) | Lua/Neovim API errors |
 

--- a/obsidian/07-neovim.md
+++ b/obsidian/07-neovim.md
@@ -72,6 +72,17 @@ These keymaps activate when an LSP server attaches to a buffer:
 | `gO` | Document symbols |
 | `gW` | Workspace symbols |
 
+### Git (Space g)
+
+| Shortcut | Action |
+|----------|--------|
+| `Space gd` | Open diff view (all working changes, side-by-side) |
+| `Space gh` | File history for current file |
+| `Space gH` | File history for entire repo |
+| `Space gc` | Close diff view |
+
+Inside diffview: `Tab`/`Shift+Tab` to cycle files, `Enter` to open a diff, `Space e` to focus file panel, `Space b` to toggle file panel.
+
 ### Toggle (Space t)
 
 | Shortcut | Action |
@@ -195,6 +206,7 @@ Diagnostics show inline as virtual text. Errors are underlined. Use `[d` / `]d` 
 | **blink.cmp** | Autocompletion with LSP + snippets |
 | **LuaSnip** | Snippet engine |
 | **conform.nvim** | Auto-format on save |
+| **diffview.nvim** | Side-by-side diff viewer and file history |
 | **gitsigns.nvim** | Git change indicators in the gutter (+, ~, _) |
 | **which-key.nvim** | Shows available keybindings after pressing a key |
 | **todo-comments.nvim** | Highlights TODO/FIXME/HACK in comments |
@@ -204,6 +216,28 @@ Diagnostics show inline as virtual text. Errors are underlined. Use `[d` / `]d` 
 | **guess-indent.nvim** | Auto-detects file indentation |
 | **nvim-web-devicons** | File type icons (Nerd Font) |
 | **lazy.nvim** | Plugin manager (auto-bootstraps on first run) |
+
+## Reviewing Claude-generated code
+
+Typical workflow after Claude makes changes:
+
+```
+Space gd            Open side-by-side diff of all working changes
+Tab / Shift+Tab     Cycle through changed files
+]d / [d             Jump between diagnostics (errors/warnings)
+Space sd            Search ALL diagnostics across the project
+grd                 Jump into a definition to verify it exists
+grr                 Find all references to check nothing was missed
+Space sg            Grep for a pattern Claude might have missed
+Space gc            Close diff view when done
+```
+
+Quick audit checklist:
+1. `Space gd` — scan the full diff, file by file
+2. `]d` in each file — check for LSP errors/warnings
+3. `grr` on key symbols — confirm all call sites were updated
+4. `Space sg` — search for old names/patterns that should have been replaced
+5. `:ConformInfo` — verify formatting is clean
 
 ## Git commit authoring
 

--- a/obsidian/07-neovim.md
+++ b/obsidian/07-neovim.md
@@ -201,11 +201,14 @@ Formatters are auto-installed by Mason on first launch.
 
 LSP provides go-to-definition, references, rename, diagnostics, and more. Servers are auto-installed by Mason:
 
-| Language | Server |
-|----------|--------|
-| JavaScript/TypeScript | ts_ls |
-| Python | pyright |
-| Lua | lua_ls (Neovim-aware) |
+| Language | Server | What it catches |
+|----------|--------|-----------------|
+| JavaScript/TypeScript | ts_ls | Type errors, missing imports, bad references |
+| JavaScript/TypeScript | eslint | Lint rules, unused vars, React hooks, style |
+| Python | pyright | Type errors, missing imports |
+| Lua | lua_ls (Neovim-aware) | Lua/Neovim API errors |
+
+All servers are auto-installed by Mason on first launch. ESLint reads your project's `.eslintrc.*` or `eslint.config.*` — no extra setup needed. Use `gra` on any ESLint diagnostic to apply the suggested fix.
 
 Diagnostics show inline as virtual text. Errors are underlined. Use `[d` / `]d` to jump between diagnostics (auto-opens float).
 

--- a/obsidian/07-neovim.md
+++ b/obsidian/07-neovim.md
@@ -25,17 +25,65 @@ The golden rule: **press `Esc` when confused**. It always returns to Normal mode
 
 ## Leader key
 
-The leader key is **Space**. All custom shortcuts start with it.
+The leader key is **Space**. All custom shortcuts start with it. Press Space and wait to see all available keybindings via which-key.
+
+### Quick actions
 
 | Shortcut | Action |
 |----------|--------|
 | `Space w` | Save file |
 | `Space q` | Quit |
-| `Space f` | Find files (telescope) |
-| `Space g` | Live grep across project (telescope) |
-| `Space b` | Switch between open buffers |
+| `Space f` | Format buffer (LSP/formatter) |
 | `Space /` | Fuzzy search current file |
-| `Space ss` | Strip trailing whitespace |
+| `Space Space` | Switch between open buffers |
+
+### Search (Space s)
+
+All search commands use Telescope and are grouped under `Space s`:
+
+| Shortcut | Action |
+|----------|--------|
+| `Space sf` | Search files (respects .gitignore) |
+| `Space sg` | Search by grep across project (ripgrep) |
+| `Space sh` | Search help tags |
+| `Space sk` | Search keymaps |
+| `Space ss` | Search select (Telescope builtins) |
+| `Space sw` | Search current word under cursor |
+| `Space sd` | Search diagnostics |
+| `Space sr` | Resume last search |
+| `Space s.` | Search recent files |
+| `Space sc` | Search commands |
+| `Space s/` | Live grep in open files |
+| `Space sn` | Search neovim config files |
+
+### LSP navigation (g prefix)
+
+These keymaps activate when an LSP server attaches to a buffer:
+
+| Shortcut | Action |
+|----------|--------|
+| `grd` | Go to definition |
+| `grr` | Find references |
+| `gri` | Go to implementation |
+| `grt` | Go to type definition |
+| `grn` | Rename symbol |
+| `gra` | Code action |
+| `grD` | Go to declaration |
+| `gO` | Document symbols |
+| `gW` | Workspace symbols |
+
+### Toggle (Space t)
+
+| Shortcut | Action |
+|----------|--------|
+| `Space th` | Toggle inlay hints |
+
+### Diagnostics/Extras (Space x)
+
+| Shortcut | Action |
+|----------|--------|
+| `Space xq` | Open diagnostic quickfix list |
+| `Space xw` | Strip trailing whitespace |
 
 ## Essential motions
 
@@ -60,12 +108,21 @@ The leader key is **Space**. All custom shortcuts start with it.
 | `o` / `O` | New line below / above |
 | `dd` | Delete line |
 | `yy` | Copy (yank) line |
+| `Y` | Yank to end of line |
 | `p` | Paste after cursor |
 | `u` | Undo |
 | `Ctrl+r` | Redo |
 | `ciw` | Change inner word (delete word + enter insert mode) |
 | `ci"` | Change inside quotes |
 | `di(` | Delete inside parentheses |
+
+### Surround (mini.surround)
+
+| Key | Action |
+|-----|--------|
+| `saiw)` | Surround add inner word with parens |
+| `sd'` | Surround delete quotes |
+| `sr)"` | Surround replace parens with quotes |
 
 ### Search
 
@@ -84,30 +141,68 @@ The leader key is **Space**. All custom shortcuts start with it.
 | `:vs` | Vertical split |
 | `:sp` | Horizontal split |
 
-## Telescope (fuzzy finder)
+## Autocompletion
 
-Telescope is the primary way to navigate files and code. All searches are fuzzy.
+Autocompletion is powered by blink.cmp with LSP integration:
 
-```
-Space f     → find files (respects .gitignore)
-Space g     → grep across all files (uses ripgrep)
-Space b     → switch buffers
-Space /     → search within current file
-```
+| Key | Action |
+|-----|--------|
+| `Ctrl+y` | Accept completion |
+| `Ctrl+n` / `Ctrl+p` | Next / previous suggestion |
+| `Ctrl+space` | Open completion menu / docs |
+| `Ctrl+e` | Dismiss completion |
+| `Ctrl+k` | Toggle signature help |
+| `Tab` / `Shift+Tab` | Navigate snippet fields |
 
-Inside telescope:
-- Type to filter results
-- `Ctrl+n` / `Ctrl+p` to move up/down
-- `Enter` to open
-- `Esc` to close
+Documentation auto-shows after 250ms when a completion is highlighted.
+
+## Auto-formatting
+
+Files are auto-formatted on save using conform.nvim. Manual format with `Space f`.
+
+| Language | Formatter |
+|----------|-----------|
+| Lua | stylua |
+| JS/TS/JSON/YAML/HTML/CSS/Markdown | prettierd (falls back to prettier) |
+| Python | black |
+
+Formatters are auto-installed by Mason on first launch.
+
+## LSP (Language Server Protocol)
+
+LSP provides go-to-definition, references, rename, diagnostics, and more. Servers are auto-installed by Mason:
+
+| Language | Server |
+|----------|--------|
+| JavaScript/TypeScript | ts_ls |
+| Python | pyright |
+| Lua | lua_ls (Neovim-aware) |
+
+Diagnostics show inline as virtual text. Errors are underlined. Use `[d` / `]d` to jump between diagnostics (auto-opens float).
 
 ## Plugins installed
 
 | Plugin | What it does |
 |--------|-------------|
 | **catppuccin** | Color theme matching Ghostty |
-| **telescope.nvim** | Fuzzy finder for files, grep, buffers |
-| **nvim-treesitter** | Syntax highlighting for JS/TS/JSON/YAML/Python/Lua/Markdown/Bash/HTML/CSS |
+| **telescope.nvim** | Fuzzy finder for files, grep, LSP, buffers, help |
+| **telescope-fzf-native** | Faster fuzzy matching in Telescope |
+| **telescope-ui-select** | Telescope-powered selection menus |
+| **nvim-treesitter** | Syntax highlighting for JS/TS/JSON/YAML/Python/Lua/Markdown/Bash/HTML/CSS and more |
+| **nvim-lspconfig** | Language server configuration |
+| **mason.nvim** | Auto-installs LSP servers and formatters |
+| **fidget.nvim** | LSP progress notifications |
+| **blink.cmp** | Autocompletion with LSP + snippets |
+| **LuaSnip** | Snippet engine |
+| **conform.nvim** | Auto-format on save |
+| **gitsigns.nvim** | Git change indicators in the gutter (+, ~, _) |
+| **which-key.nvim** | Shows available keybindings after pressing a key |
+| **todo-comments.nvim** | Highlights TODO/FIXME/HACK in comments |
+| **mini.ai** | Better around/inside text objects |
+| **mini.surround** | Add/delete/replace surrounding brackets, quotes |
+| **mini.statusline** | Lightweight status bar |
+| **guess-indent.nvim** | Auto-detects file indentation |
+| **nvim-web-devicons** | File type icons (Nerd Font) |
 | **lazy.nvim** | Plugin manager (auto-bootstraps on first run) |
 
 ## Git commit authoring
@@ -127,6 +222,8 @@ This matches the conventional commit format in `.gitmessage`.
 | JS/TS/JSON/YAML/TOML/Lua | 2 spaces |
 | Python | 4 spaces |
 
+guess-indent.nvim also auto-detects indentation from existing files.
+
 ## Config location
 
 ```
@@ -134,6 +231,10 @@ This matches the conventional commit format in `.gitmessage`.
 ```
 
 Single-file config. Everything in one place -- no plugin directory sprawl.
+
+## First launch
+
+On first launch, lazy.nvim will auto-install all plugins and Mason will download LSP servers + formatters. This may take a minute. Run `:checkhealth` to verify everything is working.
 
 ## Common operations cheat sheet
 
@@ -143,12 +244,21 @@ v file.js           Open a file
 :q                  Quit
 :wq                 Save and quit
 :q!                 Quit without saving
-Space f             Find and open a file
-Space g             Search for text across files
+Space sf            Find and open a file
+Space sg            Search for text across files
+Space f             Format current buffer
+Space Space         Switch buffers
+grd                 Go to definition
+grr                 Find references
+grn                 Rename symbol
 dd                  Delete a line
 yy p                Copy a line, paste it
 u                   Undo
 ciw                 Replace a word
+saiw"               Surround word with quotes
 /search             Find text in file
 :%s/old/new/g       Find and replace in file
+:Lazy               Open plugin manager
+:Mason              Open LSP/tool installer
+:ConformInfo        Check formatter status
 ```

--- a/obsidian/07-neovim.md
+++ b/obsidian/07-neovim.md
@@ -72,7 +72,9 @@ These keymaps activate when an LSP server attaches to a buffer:
 | `gO` | Document symbols |
 | `gW` | Workspace symbols |
 
-### Git (Space g)
+### Git (Space g) and Hunks (Space h)
+
+**Diffview:**
 
 | Shortcut | Action |
 |----------|--------|
@@ -82,6 +84,22 @@ These keymaps activate when an LSP server attaches to a buffer:
 | `Space gc` | Close diff view |
 
 Inside diffview: `Tab`/`Shift+Tab` to cycle files, `Enter` to open a diff, `Space e` to focus file panel, `Space b` to toggle file panel.
+
+**Hunk navigation and actions (gitsigns):**
+
+| Shortcut | Action |
+|----------|--------|
+| `]h` / `[h` | Jump to next / previous hunk |
+| `Space hp` | Preview hunk (inline popup) |
+| `Space hs` | Stage hunk (accept this change) |
+| `Space hu` | Undo stage hunk |
+| `Space hr` | Reset hunk (discard this change) |
+| `Space hS` | Stage entire buffer |
+| `Space hR` | Reset entire buffer |
+| `Space hb` | Blame line (who wrote this) |
+| `Space hd` | Diff this file against index |
+
+Visual mode: select lines then `Space hs` to stage or `Space hr` to reset just the selection.
 
 ### Toggle (Space t)
 
@@ -224,6 +242,8 @@ Typical workflow after Claude makes changes:
 ```
 Space gd            Open side-by-side diff of all working changes
 Tab / Shift+Tab     Cycle through changed files
+]h / [h             Jump between changed hunks
+Space hp            Preview a hunk inline
 ]d / [d             Jump between diagnostics (errors/warnings)
 Space sd            Search ALL diagnostics across the project
 grd                 Jump into a definition to verify it exists
@@ -232,12 +252,20 @@ Space sg            Grep for a pattern Claude might have missed
 Space gc            Close diff view when done
 ```
 
+Accepting or rejecting changes at the hunk level:
+- `Space hs` — stage this hunk (accept it)
+- `Space hr` — reset this hunk (discard it)
+- Select lines in visual mode, then `Space hs` / `Space hr` for partial hunks
+- `Space hS` — accept the entire file
+- `Space hR` — discard the entire file
+
 Quick audit checklist:
 1. `Space gd` — scan the full diff, file by file
-2. `]d` in each file — check for LSP errors/warnings
-3. `grr` on key symbols — confirm all call sites were updated
-4. `Space sg` — search for old names/patterns that should have been replaced
-5. `:ConformInfo` — verify formatting is clean
+2. `]h` to walk through hunks, `Space hp` to preview each
+3. `]d` in each file — check for LSP errors/warnings
+4. `grr` on key symbols — confirm all call sites were updated
+5. `Space sg` — search for old names/patterns that should have been replaced
+6. `Space hs` / `Space hr` — accept or reject each hunk
 
 ## Git commit authoring
 

--- a/obsidian/07-neovim.md
+++ b/obsidian/07-neovim.md
@@ -238,37 +238,137 @@ Diagnostics show inline as virtual text. Errors are underlined. Use `[d` / `]d` 
 | **nvim-web-devicons** | File type icons (Nerd Font) |
 | **lazy.nvim** | Plugin manager (auto-bootstraps on first run) |
 
-## Reviewing Claude-generated code
+## How to review Claude-generated code
 
-Typical workflow after Claude makes changes:
+This is the core workflow for steering Claude and reviewing its output as fast as possible. The goal: see exactly what changed, verify correctness with LSP, accept or reject at the hunk level, and commit only what you approve.
+
+### Step 1: See everything that changed
 
 ```
-Space gd            Open side-by-side diff of all working changes
-Tab / Shift+Tab     Cycle through changed files
-]h / [h             Jump between changed hunks
-Space hp            Preview a hunk inline
-]d / [d             Jump between diagnostics (errors/warnings)
-Space sd            Search ALL diagnostics across the project
-grd                 Jump into a definition to verify it exists
-grr                 Find all references to check nothing was missed
-Space sg            Grep for a pattern Claude might have missed
-Space gc            Close diff view when done
+Space gd
 ```
 
-Accepting or rejecting changes at the hunk level:
-- `Space hs` — stage this hunk (accept it)
-- `Space hr` — reset this hunk (discard it)
-- Select lines in visual mode, then `Space hs` / `Space hr` for partial hunks
-- `Space hS` — accept the entire file
-- `Space hR` — discard the entire file
+Opens diffview — a side-by-side diff of every file Claude modified. The left panel lists changed files, the right shows the diff. This is your starting point for every review.
 
-Quick audit checklist:
-1. `Space gd` — scan the full diff, file by file
-2. `]h` to walk through hunks, `Space hp` to preview each
-3. `]d` in each file — check for LSP errors/warnings
-4. `grr` on key symbols — confirm all call sites were updated
-5. `Space sg` — search for old names/patterns that should have been replaced
-6. `Space hs` / `Space hr` — accept or reject each hunk
+**Navigate between files:**
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Next changed file |
+| `Shift+Tab` | Previous changed file |
+| `Enter` | Open diff for selected file |
+| `Space gc` | Close diffview when done |
+
+### Step 2: Walk through hunks
+
+Inside a file, hunks are the individual blocks of changed code. Jump between them instead of scrolling:
+
+| Key | Action |
+|-----|--------|
+| `]h` | Jump to next hunk |
+| `[h` | Jump to previous hunk |
+| `Space hp` | Preview hunk as an inline popup (quick glance without leaving your position) |
+
+### Step 3: Check for errors
+
+LSP catches problems Claude introduced — type errors, missing imports, bad references, ESLint violations — without running anything:
+
+| Key | Action |
+|-----|--------|
+| `]d` | Jump to next diagnostic (error/warning) |
+| `[d` | Jump to previous diagnostic |
+| `Space sd` | Search ALL diagnostics across every file in the project |
+| `gra` | Apply a quick fix (ESLint auto-fix, add missing import, etc.) |
+
+### Step 4: Verify correctness
+
+When something looks suspicious, dig deeper:
+
+| Key | Action |
+|-----|--------|
+| `grd` | Go to definition — verify the function/variable Claude referenced actually exists |
+| `grr` | Find all references — check if Claude missed updating a call site |
+| `gri` | Go to implementation — see the actual code behind an interface |
+| `Space sw` | Search for the word under cursor across the entire project |
+| `Space sg` | Grep for any pattern — find old names that should have been renamed |
+
+### Step 5: Accept or reject each change
+
+This is the key to a tight feedback loop. You don't have to accept or reject an entire file — you work at the **hunk level**:
+
+**Accept a change (stage it):**
+```
+Space hs        Stage this hunk — you're keeping it
+```
+
+**Reject a change (discard it):**
+```
+Space hr        Reset this hunk — reverts it to what was there before
+```
+
+**Partial hunks — accept or reject specific lines within a hunk:**
+1. Enter visual mode: `V` then `j`/`k` to select lines
+2. `Space hs` to stage just those lines
+3. Or `Space hr` to reset just those lines
+
+**Whole file shortcuts:**
+
+| Key | Action |
+|-----|--------|
+| `Space hS` | Stage entire buffer (accept all changes in this file) |
+| `Space hR` | Reset entire buffer (discard all changes in this file) |
+| `Space hu` | Undo last stage (if you staged a hunk by mistake) |
+
+### Step 6: Verify what you staged
+
+Before committing, confirm you only staged what you intended:
+
+```
+Space hd        Diff this file against the index — see what's staged vs not
+Space gd        Re-open diffview to scan remaining unstaged changes
+```
+
+### Step 7: Commit only approved changes
+
+After staging the hunks you want, commit from the terminal or lazygit:
+
+```bash
+# From terminal
+git commit
+
+# Or use lazygit (alias: lg) for a visual staging/commit interface
+lg
+```
+
+Neovim opens for the commit message with spell check, 72-char wrapping, and auto-insert mode.
+
+### Quick reference card
+
+The full review loop in one block:
+
+```
+Space gd            1. Open side-by-side diff
+Tab / Shift+Tab     2. Cycle through changed files
+]h / [h             3. Walk through hunks
+Space hp            4. Preview a hunk inline
+]d / [d             5. Check for LSP errors
+grd / grr           6. Verify definitions and references
+Space hs            7. Stage hunk (accept)
+Space hr            8. Reset hunk (reject)
+V + j/k + Space hs  9. Stage partial hunk (accept specific lines)
+V + j/k + Space hr  10. Reset partial hunk (reject specific lines)
+Space gc            11. Close diffview
+git commit          12. Commit what you staged
+```
+
+### Tips for speed
+
+- **Don't read every line.** Use `]h` to hop between hunks — the gutter signs (`+`/`~`/`_`) show you where to look.
+- **Trust the LSP.** If there are zero diagnostics after `Space sd`, type-level correctness is confirmed. Focus your eyeballs on logic, not syntax.
+- **Use `grr` on anything Claude renamed.** If references count matches what you expect, the rename was complete.
+- **Reject first, ask later.** If a hunk looks wrong, `Space hr` immediately. You can always ask Claude to redo just that part. Faster than trying to manually fix it.
+- **Partial hunks for mixed changes.** Claude often adds something good and something unnecessary in the same block. `V` select the good lines, `Space hs`, then `Space hr` the rest.
+- **`Space sg` is your safety net.** After Claude does a rename or refactor, grep for the old name. If it shows up anywhere, Claude missed a spot.
 
 ## Git commit authoring
 


### PR DESCRIPTION
Merge kickstart.nvim capabilities into the existing single-file init.lua
while preserving personal customizations (Catppuccin theme, git commit
authoring, custom keymaps, file-type indent settings).

New features added:
- LSP support (ts_ls, pyright, lua_ls) with Mason auto-install
- Autocompletion (blink.cmp + LuaSnip) with signature help
- Auto-format on save (conform.nvim: prettierd, black, stylua)
- Git gutter signs (gitsigns.nvim)
- Keybinding discovery (which-key.nvim)
- Enhanced Telescope (fzf-native, ui-select, 12+ search commands)
- Mini modules (ai textobjects, surround, statusline)
- TODO/FIXME comment highlighting
- Auto indent detection (guess-indent.nvim)
- Diagnostic config with virtual text and float on jump
- Yank highlighting, terminal mode exit, whitespace visualization

Updated obsidian/07-neovim.md with complete documentation of all new
keybindings, plugins, LSP servers, formatters, and autocompletion usage.

https://claude.ai/code/session_01F53UzSPRZ9RAJBHH2RYshd