### PR TITLE
docs(obsidian): add Dev Home README and migrate quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The `obsidian/` folder contains developer workflow notes for every tool in the s
 
 | Doc | Covers |
 |-----|--------|
+| [README](obsidian/README.md) | **Dev Home -- start here** |
 | [00-stack](obsidian/00-stack.md) | Full stack overview and principles |
 | [01-ghostty-starship](obsidian/01-ghostty-starship.md) | Terminal + prompt config and keybindings |
 | [02-claude-code](obsidian/02-claude-code.md) | Agent workflow, aliases, project setup |
@@ -184,6 +185,8 @@ The `obsidian/` folder contains developer workflow notes for every tool in the s
 | [11-lazygit](obsidian/11-lazygit.md) | TUI for staging, rebasing, conflicts |
 | [12-github-cli](obsidian/12-github-cli.md) | PRs, issues, API, completions |
 | [13-zsh-shell](obsidian/13-zsh-shell.md) | Plugins, history, functions, shell options |
+| [14-claude-pkm](obsidian/14-claude-pkm.md) | Private Obsidian vault for persistent knowledge |
+| [15-quickstart](obsidian/15-quickstart.md) | Install, post-install checklist, day-one commands |
 
 ## Maintenance
 

--- a/obsidian/00-stack.md
+++ b/obsidian/00-stack.md
@@ -1,5 +1,7 @@
 # The Stack
 
+> Back to [[README|Dev Home]] | New here? See [[15-quickstart|Quickstart]]
+
 The entire development environment fits in one idea: **the agent writes the code, you steer**.
 
 ## Tools

--- a/obsidian/15-quickstart.md
+++ b/obsidian/15-quickstart.md
@@ -1,0 +1,99 @@
+# Quickstart
+
+Get from zero to working dev environment in one command.
+
+## Install
+
+```bash
+git clone https://github.com/jamesfdavis/dotfiles.git ~/dotfiles
+cd ~/dotfiles && ./install.sh
+```
+
+Five steps run automatically:
+
+1. **Homebrew** -- installs all packages from `Brewfile`
+2. **Symlinks** -- dotfiles and `~/.config` directories
+3. **SSH keys** -- generates auth + signing key pair, configures macOS Keychain persistence
+4. **Node.js** -- installs LTS via NVM
+5. **npm globals** -- installs `claude-code` and `wrangler`
+
+## Post-install checklist
+
+1. Restart your terminal (or `source ~/.zshrc`)
+2. Register both SSH keys on GitHub -- the install script prints them
+   - `~/.ssh/id_ed25519.pub` -> **Authentication** key
+   - `~/.ssh/id_ed25519_signing.pub` -> **Signing** key
+3. Set up secrets: `cp ~/.extra.example ~/.extra && nvim ~/.extra`
+4. Auth GitHub CLI: `gh auth login`
+5. Start Colima: `colima start`
+
+## What you get
+
+| What | Tool | Key alias | Reference |
+|------|------|-----------|-----------|
+| Terminal | Ghostty (Catppuccin Mocha) | -- | [[01-ghostty-starship]] |
+| Shell | Zsh + Starship prompt | -- | [[13-zsh-shell]] |
+| AI agent | Claude Code | `cc` | [[02-claude-code]] |
+| Editor | Neovim (Telescope, Treesitter) | `v` | [[07-neovim]] |
+| Git UI | Lazygit | `lg` | [[11-lazygit]] |
+| Git | SSH-signed commits, rebase-by-default | `gs` `ga` `gcm` `gp` | [[05-git-workflow]] |
+| Search | ripgrep + fd + fzf | `rg` `fd` `Ctrl+T` | [[08-fzf-ripgrep-fd]] |
+| Node | NVM with auto .nvmrc switching | lazy-loaded | [[10-node-nvm]] |
+| Python | uv | `uvv` `uva` | [[06-python-uv]] |
+| Cloudflare | Wrangler | `wr` `wrd` `wrp` | [[03-cloudflare]] |
+| Smart cd | zoxide | `z <dir>` | [[09-cli-utilities]] |
+| Docker | Colima + Docker Compose | `dc` `dcu` `dcd` | [[04-docker]] |
+| GitHub | gh CLI | `ghpr` `ghprw` | [[12-github-cli]] |
+
+## Day-one commands
+
+```bash
+dot           # jump to ~/dotfiles
+cc            # launch Claude Code
+lg            # open lazygit
+v .           # open current dir in neovim
+z <dir>       # smart directory jump
+tre           # pretty tree view (3 levels)
+brewup        # update all Homebrew packages
+cleanup       # remove node_modules, dist, .wrangler, .DS_Store
+genpass       # generate a secure random password
+myip          # show external IP
+serve         # quick Python HTTP server on port 8000
+```
+
+## Workflow
+
+Features follow: **Scaffold -> Plan -> Issues -> Build -> Verify**
+
+See [[02-claude-code|Claude Code]] for the full workflow breakdown, or [[README|Dev Home]] for the quick reference.
+
+In Claude Code, use the slash commands:
+
+- `/scaffold` -- generate a new SvelteKit PWA + Cloudflare project
+- `/plan` -- research codebase, draft stack-aware design, get approval
+- `/issues` -- break plan into sized GitHub issues with dependency links
+- `/build` -- layered TDD: unit -> component -> E2E, then commit
+- `/verify` -- browser-based UI verification via `claude --chrome`
+
+Skip steps when appropriate: existing project? skip `/scaffold`. Small fix? skip to `/build`. No UI? skip `/verify`.
+
+## Git aliases
+
+```bash
+gs            # git status
+ga            # git add
+gcm "msg"     # git commit -m
+gp            # git push
+gl            # git pull
+glog          # git log --graph
+uncommit      # undo last commit (soft reset)
+```
+
+See [[05-git-workflow|Git Workflow]] for the full list and branching strategy.
+
+## Updating
+
+```bash
+cd ~/dotfiles && git pull    # symlinks update instantly
+brewup                       # update Homebrew packages
+```

--- a/obsidian/README.md
+++ b/obsidian/README.md
@@ -1,0 +1,163 @@
+# Dev Home
+
+> One page to rule them all. Open this vault in Obsidian or read the markdown directly.
+
+## Quick Start
+
+New machine? See [[15-quickstart|Quickstart Guide]] for install, post-install checklist, and day-one commands.
+
+```bash
+git clone https://github.com/jamesfdavis/dotfiles.git ~/dotfiles
+cd ~/dotfiles && ./install.sh
+```
+
+## Developer Workflow
+
+The agent writes the code, you steer. Everything runs in the terminal.
+
+```mermaid
+graph LR
+    S["/scaffold"] --> P["/plan"]
+    P --> I["/issues"]
+    I --> B["/build"]
+    B --> V["/verify"]
+    V --> C["Commit & PR"]
+
+    P -.->|small task| B
+    B -.->|no UI| C
+```
+
+| Phase | Command | What happens |
+|-------|---------|--------------|
+| Generate | `/scaffold` | New SvelteKit PWA + Cloudflare project |
+| Design | `/plan` | Research codebase, draft stack-aware design, get approval |
+| Track | `/issues` | Break plan into sized, ordered GitHub issues |
+| Implement | `/build` | Layered TDD: unit (vitest) -> component (testing-library) -> E2E (playwright) |
+| Verify | `/verify` | Browser-based UI verification via `claude --chrome` |
+| Ship | `gh pr create` | Conventional commit, open PR |
+
+Skip steps when appropriate -- existing project? skip `/scaffold`. Small fix? straight to `/build`. No UI? skip `/verify`.
+
+## Vault Index
+
+Every tool in the stack has a dedicated reference doc.
+
+| Doc | Covers |
+|-----|--------|
+| [[00-stack|The Stack]] | Full stack overview and principles |
+| [[01-ghostty-starship|Ghostty + Starship]] | Terminal config, keybindings, prompt |
+| [[02-claude-code|Claude Code]] | Agent workflow, aliases, slash commands, browser loop |
+| [[03-cloudflare|Cloudflare]] | Workers, D1, KV, R2, Wrangler aliases |
+| [[04-docker|Docker]] | Colima, Docker Compose, cleanup |
+| [[05-git-workflow|Git Workflow]] | Aliases, commit signing, branch strategy |
+| [[06-python-uv|Python + uv]] | Fast venvs, pip installs, Jupyter |
+| [[07-neovim|Neovim]] | Keybindings, motions, Telescope, LSP, plugins |
+| [[08-fzf-ripgrep-fd|FZF + ripgrep + fd]] | Fuzzy finding, code search, file discovery |
+| [[09-cli-utilities|CLI Utilities]] | bat, eza, zoxide, jq |
+| [[10-node-nvm|Node + NVM]] | Lazy loading, .nvmrc auto-switch, npm aliases |
+| [[11-lazygit|Lazygit]] | TUI for staging, rebasing, conflict resolution |
+| [[12-github-cli|GitHub CLI]] | PRs, issues, API calls, completions |
+| [[13-zsh-shell|Zsh Shell]] | Plugins, history, functions, shell options |
+| [[14-claude-pkm|Claude PKM]] | Private Obsidian vault for persistent knowledge |
+| [[15-quickstart|Quickstart]] | Install, post-install checklist, day-one commands |
+
+## External Docs
+
+Official documentation for the core stack.
+
+### Frontend & Framework
+
+| Tool | Docs |
+|------|------|
+| SvelteKit | [kit.svelte.dev/docs](https://kit.svelte.dev/docs) |
+| Svelte 5 (Runes) | [svelte.dev/docs/svelte](https://svelte.dev/docs/svelte) |
+| Tailwind CSS v4 | [tailwindcss.com/docs](https://tailwindcss.com/docs) |
+| Vite | [vite.dev/guide](https://vite.dev/guide/) |
+| vite-plugin-pwa | [vite-pwa-org.netlify.app/guide](https://vite-pwa-org.netlify.app/guide/) |
+
+### Platform & Deploy
+
+| Tool | Docs |
+|------|------|
+| Cloudflare Workers | [developers.cloudflare.com/workers](https://developers.cloudflare.com/workers/) |
+| Cloudflare D1 | [developers.cloudflare.com/d1](https://developers.cloudflare.com/d1/) |
+| Cloudflare KV | [developers.cloudflare.com/kv](https://developers.cloudflare.com/kv/) |
+| Cloudflare R2 | [developers.cloudflare.com/r2](https://developers.cloudflare.com/r2/) |
+| Cloudflare Pages | [developers.cloudflare.com/pages](https://developers.cloudflare.com/pages/) |
+| Wrangler CLI | [developers.cloudflare.com/workers/wrangler](https://developers.cloudflare.com/workers/wrangler/) |
+
+### Testing
+
+| Tool | Docs |
+|------|------|
+| Vitest | [vitest.dev/guide](https://vitest.dev/guide/) |
+| Testing Library (Svelte) | [testing-library.com/docs/svelte-testing-library/intro](https://testing-library.com/docs/svelte-testing-library/intro/) |
+| Playwright | [playwright.dev/docs/intro](https://playwright.dev/docs/intro) |
+
+### AI & Agent
+
+| Tool | Docs |
+|------|------|
+| Claude Code | [docs.anthropic.com/en/docs/claude-code](https://docs.anthropic.com/en/docs/claude-code/) |
+| Claude Code CLI | [docs.anthropic.com/en/docs/claude-code/cli-usage](https://docs.anthropic.com/en/docs/claude-code/cli-usage) |
+
+### Dev Tools
+
+| Tool | Docs |
+|------|------|
+| Ghostty | [ghostty.org/docs](https://ghostty.org/docs) |
+| Neovim | [neovim.io/doc](https://neovim.io/doc/) |
+| Starship | [starship.rs/config](https://starship.rs/config/) |
+| ripgrep | [github.com/BurntSushi/ripgrep/blob/master/GUIDE.md](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md) |
+| fd | [github.com/sharkdp/fd#how-to-use](https://github.com/sharkdp/fd#how-to-use) |
+| fzf | [github.com/junegunn/fzf#usage](https://github.com/junegunn/fzf#usage) |
+| bat | [github.com/sharkdp/bat#how-to-use](https://github.com/sharkdp/bat#how-to-use) |
+| eza | [github.com/eza-community/eza#usage](https://github.com/eza-community/eza#usage) |
+| zoxide | [github.com/ajeetdsouza/zoxide#usage](https://github.com/ajeetdsouza/zoxide#usage) |
+| lazygit | [github.com/jesseduffield/lazygit#usage](https://github.com/jesseduffield/lazygit#usage) |
+| GitHub CLI | [cli.github.com/manual](https://cli.github.com/manual/) |
+
+### Languages & Runtimes
+
+| Tool | Docs |
+|------|------|
+| Node.js | [nodejs.org/docs/latest/api](https://nodejs.org/docs/latest/api/) |
+| NVM | [github.com/nvm-sh/nvm#usage](https://github.com/nvm-sh/nvm#usage) |
+| Python | [docs.python.org/3](https://docs.python.org/3/) |
+| uv | [docs.astral.sh/uv](https://docs.astral.sh/uv/) |
+
+### Containers
+
+| Tool | Docs |
+|------|------|
+| Docker Compose | [docs.docker.com/compose](https://docs.docker.com/compose/) |
+| Colima | [github.com/abiosoft/colima#usage](https://github.com/abiosoft/colima#usage) |
+
+## Key Aliases
+
+```bash
+# Claude Code
+cc / ccc / ccr / cci        # claude / chat / resume / init
+
+# Cloudflare
+wr / wrd / wrp / wrl        # wrangler / dev / deploy / tail
+
+# Git
+lg                          # lazygit
+gs / ga / gcm / gp / gl     # status / add / commit / push / pull
+
+# Navigation
+z <dir>                     # smart directory jump (zoxide)
+
+# Editors
+v / c / c.                  # nvim / code / code .
+```
+
+Full alias list: `~/.aliases` or run `alias` in any shell.
+
+## Maintenance
+
+```bash
+brewup                      # update all Homebrew packages
+cd ~/dotfiles && git pull   # symlinks update instantly
+```


### PR DESCRIPTION
Add obsidian/README.md as a single landing page for the vault with
developer workflow, links to all 15 tool reference docs, and external
documentation links for SvelteKit, Cloudflare, Tailwind, Vitest,
Playwright, and every CLI tool in the stack.

Migrate docs/QUICKSTART.md into obsidian/15-quickstart.md with
Obsidian wiki-links to related tool docs. Update 00-stack.md with
nav breadcrumbs and add both new files to the root README table.

https://claude.ai/code/session_014GaivZUTHm8d5k4oVV3Y71