### PR TITLE
feat: add llms.txt support for LLM-friendly documentation

### DIFF
--- a/.functions
+++ b/.functions
@@ -90,3 +90,36 @@ function genpass() {
     local length="${1:-24}"
     openssl rand -base64 "$length" | tr -d "=+/" | cut -c1-"$length"
 }
+
+# Fetch llms.txt from any domain
+# Usage: llmstxt svelte.dev           → fetches https://svelte.dev/llms.txt
+#        llmstxt svelte.dev full      → fetches https://svelte.dev/llms-full.txt
+#        llmstxt svelte.dev small     → fetches https://svelte.dev/llms-small.txt
+function llmstxt() {
+    if [[ -z "$1" ]]; then
+        echo "Usage: llmstxt <domain> [full|small|medium]"
+        echo "  llmstxt svelte.dev        → /llms.txt"
+        echo "  llmstxt svelte.dev full   → /llms-full.txt"
+        return 1
+    fi
+
+    local domain="$1"
+    local variant="${2:-}"
+    local url
+
+    if [[ -n "$variant" ]]; then
+        url="https://${domain}/llms-${variant}.txt"
+    else
+        url="https://${domain}/llms.txt"
+    fi
+
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" "$url" 2>/dev/null)
+
+    if [[ "$status" == "200" ]]; then
+        curl -s "$url" 2>/dev/null
+    else
+        echo "No llms.txt found at $url (HTTP $status)"
+        return 1
+    fi
+}

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -57,6 +57,27 @@ Skip steps when appropriate:
 
 After making any frontend changes, visually verify in Chrome before reporting completion (if `claude --chrome` is available).
 
+## LLM-Friendly Documentation (llms.txt)
+
+When looking up framework or platform docs, prefer fetching llms.txt URLs over browsing full documentation sites. These are concise, LLM-optimized, and version-matched.
+
+### Stack docs (curated)
+
+| Library | URL | Notes |
+|---------|-----|-------|
+| SvelteKit | `https://svelte.dev/docs/kit/llms.txt` | SvelteKit-specific |
+| Svelte | `https://svelte.dev/llms-small.txt` | Svelte 5 compressed |
+| Svelte (full) | `https://svelte.dev/llms-full.txt` | Complete Svelte + SvelteKit |
+| Cloudflare Workers | `https://developers.cloudflare.com/workers/llms-full.txt` | Workers API |
+| Cloudflare Pages | `https://developers.cloudflare.com/pages/llms-full.txt` | Pages deployment |
+| Cloudflare Agents | `https://developers.cloudflare.com/agents/llms-full.txt` | Agents SDK |
+| Cloudflare (index) | `https://developers.cloudflare.com/llms.txt` | All products index |
+| Vite | `https://vite.dev/llms.txt` | Build tooling |
+
+Tailwind CSS v4 has no official llms.txt. Use training data or fetch docs manually.
+
+For libraries not listed above, check `<domain>/llms.txt` or use the Cloudflare Docs MCP tool.
+
 ## Conventions
 
 - Conventional commits: `<type>(<scope>): <description>`

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@
 # 5. Node.js LTS via NVM
 # 6. npm globals (claude-code, wrangler)
 # 7. Chrome DevTools MCP server for Claude Code
+# 8. Cloudflare Docs MCP server for Claude Code
 
 set -e
 
@@ -46,27 +47,27 @@ echo -e "${GREEN}  Running on macOS${NC}"
 echo ""
 
 # Step 1: Homebrew
-echo -e "${YELLOW}  Step 1/7: Homebrew...${NC}"
+echo -e "${YELLOW}  Step 1/8: Homebrew...${NC}"
 "$DOTFILES_DIR/scripts/setup-homebrew.sh"
 echo ""
 
 # Step 2: Symlink dotfiles + config
-echo -e "${YELLOW}  Step 2/7: Symlinking dotfiles...${NC}"
+echo -e "${YELLOW}  Step 2/8: Symlinking dotfiles...${NC}"
 "$DOTFILES_DIR/bootstrap.sh"
 echo ""
 
 # Step 3: macOS defaults
-echo -e "${YELLOW}  Step 3/7: Applying macOS defaults...${NC}"
+echo -e "${YELLOW}  Step 3/8: Applying macOS defaults...${NC}"
 "$DOTFILES_DIR/scripts/setup-macos.sh"
 echo ""
 
 # Step 4: SSH Signing Key
-echo -e "${YELLOW}  Step 4/7: SSH commit signing + Keychain persistence...${NC}"
+echo -e "${YELLOW}  Step 4/8: SSH commit signing + Keychain persistence...${NC}"
 "$DOTFILES_DIR/scripts/setup-ssh-signing.sh"
 echo ""
 
 # Step 5: Node.js + npm globals
-echo -e "${YELLOW}  Step 5/7: Installing Node.js LTS via NVM...${NC}"
+echo -e "${YELLOW}  Step 5/8: Installing Node.js LTS via NVM...${NC}"
 
 # Determine HOMEBREW_PREFIX for NVM
 if [[ $(uname -m) == "arm64" ]]; then
@@ -87,7 +88,7 @@ else
 fi
 
 # Step 6: npm globals
-echo -e "${YELLOW}  Step 6/7: Installing npm globals...${NC}"
+echo -e "${YELLOW}  Step 6/8: Installing npm globals...${NC}"
 if command -v npm &>/dev/null; then
     npm install -g @anthropic-ai/claude-code 2>/dev/null && \
         echo -e "${GREEN}  Installed claude-code${NC}" || \
@@ -102,9 +103,15 @@ fi
 echo ""
 
 # Step 7: Chrome DevTools MCP
-echo -e "${YELLOW}  Step 7/7: Chrome DevTools MCP server...${NC}"
+echo -e "${YELLOW}  Step 7/8: Chrome DevTools MCP server...${NC}"
 "$DOTFILES_DIR/scripts/setup-chrome-mcp.sh" || \
     echo -e "${YELLOW}  Chrome MCP setup skipped (can retry: $DOTFILES_DIR/scripts/setup-chrome-mcp.sh)${NC}"
+echo ""
+
+# Step 8: Cloudflare Docs MCP
+echo -e "${YELLOW}  Step 8/8: Cloudflare Docs MCP server...${NC}"
+"$DOTFILES_DIR/scripts/setup-cloudflare-mcp.sh" || \
+    echo -e "${YELLOW}  Cloudflare Docs MCP setup skipped (can retry: $DOTFILES_DIR/scripts/setup-cloudflare-mcp.sh)${NC}"
 echo ""
 
 # Post-install verification
@@ -134,6 +141,10 @@ command -v gh &>/dev/null && \
 (claude mcp list 2>/dev/null | grep -q "chrome-devtools") && \
     echo -e "${GREEN}  Chrome DevTools MCP registered${NC}" || \
     { echo -e "${YELLOW}  Chrome DevTools MCP not registered (run: claude mcp add chrome-devtools -- npx chrome-devtools-mcp@latest)${NC}"; }
+
+(claude mcp list 2>/dev/null | grep -q "cloudflare-docs") && \
+    echo -e "${GREEN}  Cloudflare Docs MCP registered${NC}" || \
+    { echo -e "${YELLOW}  Cloudflare Docs MCP not registered (run: claude mcp add cloudflare-docs -- npx mcp-remote@latest https://docs.mcp.cloudflare.com/sse)${NC}"; }
 
 if [ "$_fail" -eq 1 ]; then
     echo ""

--- a/scripts/setup-cloudflare-mcp.sh
+++ b/scripts/setup-cloudflare-mcp.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# setup-cloudflare-mcp.sh - Register Cloudflare Docs MCP server with Claude Code
+#
+# Provides semantic search across all Cloudflare developer documentation
+# (Workers, Pages, D1, KV, R2, Agents, etc.) via the official MCP endpoint.
+#
+# Requires: claude (npm @anthropic-ai/claude-code), Node.js 18+
+# Docs: https://developers.cloudflare.com/workers/get-started/prompting/
+# ------------------------------------------------------------------------------
+set -e
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Verify prerequisites
+if ! command -v claude &>/dev/null; then
+    echo -e "  ${RED}claude not found -- install claude-code first${NC}"
+    exit 1
+fi
+
+if ! command -v npx &>/dev/null; then
+    echo -e "  ${RED}npx not found -- install Node.js first${NC}"
+    exit 1
+fi
+
+# Check if Cloudflare Docs MCP is already registered
+if claude mcp list 2>/dev/null | grep -q "cloudflare-docs"; then
+    echo -e "  ${GREEN}Cloudflare Docs MCP already registered${NC}"
+    exit 0
+fi
+
+# Register Cloudflare Docs MCP server with Claude Code
+echo "  Registering Cloudflare Docs MCP server..."
+if claude mcp add cloudflare-docs -- npx mcp-remote@latest https://docs.mcp.cloudflare.com/sse 2>/dev/null; then
+    echo -e "  ${GREEN}Cloudflare Docs MCP registered${NC}"
+else
+    echo -e "  ${YELLOW}Cloudflare Docs MCP registration failed (can retry: claude mcp add cloudflare-docs -- npx mcp-remote@latest https://docs.mcp.cloudflare.com/sse)${NC}"
+    exit 1
+fi
+
+# Verify registration
+if claude mcp list 2>/dev/null | grep -q "cloudflare-docs"; then
+    echo -e "  ${GREEN}Verified: cloudflare-docs MCP server active${NC}"
+else
+    echo -e "  ${YELLOW}Registration may need a Claude Code restart to take effect${NC}"
+fi


### PR DESCRIPTION
Add curated llms.txt URLs to CLAUDE.md for the full stack (Svelte,
SvelteKit, Cloudflare Workers/Pages/Agents, Vite), a `llmstxt` shell
function for fetching docs from any domain, and Cloudflare Docs MCP
server setup for semantic doc search during Claude Code sessions.

https://claude.ai/code/session_012JqUAuHCZ5BZGQXuJiRm16