### PR TITLE
Add summary of "Just Talk To It" by Peter Steinberger

### DIFF
--- a/summaries/dotfiles-comparison-steipete.md
+++ b/summaries/dotfiles-comparison-steipete.md
@@ -1,0 +1,156 @@
+# Dotfiles & Stack Comparison: You vs. Peter Steinberger
+
+A side-by-side comparison of your dotfiles layout and development stack against
+what Peter Steinberger describes across his two posts:
+- [Just Talk To It](https://steipete.me/posts/just-talk-to-it)
+- [Shipping at Inference Speed](https://steipete.me/posts/2025/shipping-at-inference-speed)
+
+---
+
+## Layout & Configuration Philosophy
+
+| Aspect | Your Dotfiles | Steinberger |
+|--------|---------------|-------------|
+| **Agent rules file** | `claude/CLAUDE.md` (~structured, per-project template) | `agents.md` symlinked to `claude.md` (~800 lines, "organizational scar tissue") |
+| **Who writes the rules** | You wrote and maintain them | The agent writes and maintains them -- whenever something breaks, it adds a note |
+| **Slash commands** | 5 custom commands (`/scaffold`, `/plan`, `/issues`, `/build`, `/verify`) + full skillchain system with 12 blueprints and 14 role categories | None mentioned -- prefers conversational prompting over structured commands |
+| **Documentation** | Obsidian vault (16 guides), `docs/` folder, inline llms.txt links in CLAUDE.md | `docs/` folder per project, script that forces model to read docs on certain topics |
+| **Workflow model** | Structured pipeline: scaffold -> plan -> issues -> build -> verify | Conversational: discuss -> iterate -> ship. No rigid pipeline |
+| **Setup automation** | `install.sh` (8-step), `bootstrap.sh` (symlinks), 5 setup scripts | Not detailed -- focus is on runtime workflow, not bootstrap |
+| **Git hooks** | `pre-commit` with gitleaks secret scanning | Agents do atomic commits; rules file enforces clean commit hygiene |
+
+**Takeaway:** Your setup is more structured and prescriptive (explicit workflow stages, blueprints, role categories). Steinberger's is more conversational and emergent -- the agent evolves the rules organically. Both are heavily documentation-driven, but you front-load structure while he lets it accumulate.
+
+---
+
+## Development Stack
+
+| Layer | Your Stack | Steinberger's Stack |
+|-------|-----------|-------------------|
+| **Primary language** | TypeScript (SvelteKit) | TypeScript (React), Go, Swift |
+| **Frontend** | SvelteKit + Svelte 5 (runes) | React (~300k LOC app) |
+| **Styling** | Tailwind CSS v4 | Not specified |
+| **Platform** | Cloudflare (Workers, D1, KV, R2, Pages) | Not specified (likely mixed) |
+| **Mobile** | None mentioned | Expo (React Native) |
+| **Desktop** | None mentioned | Tauri |
+| **Browser ext** | None mentioned | Chrome extension |
+| **Testing** | vitest, testing-library, Playwright | Mentioned but not detailed |
+| **AI agent** | Claude Code (sole agent) | GPT-5 Codex (primary), multi-model |
+| **Agent instances** | Single agent, sequential workflow | 3-8 parallel instances in tmux grid |
+| **Terminal** | Ghostty | tmux (terminal not specified) |
+| **Shell** | Zsh + Starship | Not detailed |
+| **Editor** | Neovim (primary), VS Code (review) | Not detailed |
+| **Git TUI** | lazygit | Not mentioned |
+| **Containers** | Colima + Docker Compose | Not mentioned |
+| **Secrets** | 1Password + gitleaks | Not detailed |
+| **CLI tools** | ripgrep, fd, fzf, bat, eza, zoxide, jq | CLIs preferred over MCPs (specific tools not listed) |
+
+**Takeaway:** Your stack is narrower and deeper -- all-in on Cloudflare + SvelteKit with a single AI agent. Steinberger's is wider -- multiple languages, multiple platforms (web, mobile, desktop, extension), multiple AI models running in parallel. You optimize for consistency; he optimizes for throughput.
+
+---
+
+## Agent Workflow Comparison
+
+| Practice | Your Approach | Steinberger's Approach |
+|----------|--------------|----------------------|
+| **Agent count** | 1 agent at a time | 3-8 agents in parallel (tmux 3x3 grid) |
+| **Agent model** | Claude Code only | GPT-5 Codex primary, multi-model |
+| **Prompting style** | Structured slash commands + skillchain roles | Conversational ("just talk to it") |
+| **Planning** | `/plan` command with stack constraints | "Discuss" and "give me options" -- no rigid plan mode |
+| **Task scoping** | GitHub issues via `/issues` command | "Blast radius thinking" -- scope to limit impact |
+| **Code review** | `/verify` with Chrome DevTools MCP | Watches stream, inspects key parts, mostly doesn't read |
+| **MCPs** | Chrome DevTools MCP, Cloudflare Docs MCP | Dismisses MCPs as "marketing checkboxes" -- prefers CLIs |
+| **Refactoring** | Not formalized | 20% cycle: jscpd, knip, ESLint, dependency updates |
+| **Cross-project** | Per-project CLAUDE.md template | Points agent at other project folders to reuse solutions |
+| **Git workflow** | Conventional commits, test-before-commit | Atomic commits by agents, clean history via rules file |
+
+**Takeaway:** The biggest divergence is on MCPs and structured commands. You've invested heavily in MCP integrations and a command pipeline. Steinberger explicitly rejects MCPs in favor of CLIs and rejects structured commands in favor of conversation. Neither is wrong -- your approach adds guardrails; his maximizes speed and flexibility.
+
+---
+
+## Cost Comparison: Claude Code vs. GPT Codex
+
+### Subscription Plans
+
+| Plan | Claude Code | GPT Codex (via ChatGPT) |
+|------|-------------|------------------------|
+| **Free** | Limited daily messages | Limited |
+| **Pro ($20/mo)** | Claude Code access, standard limits | 30-150 messages / 5 hrs |
+| **Max 5x ($100/mo)** | 5x Pro usage | -- |
+| **Max 20x ($200/mo)** | 20x Pro usage | 300-1,500 messages / 5 hrs |
+| **Team** | $150/seat/mo (Premium) | $25-30/seat/mo |
+
+### API Token Pricing (per 1M tokens)
+
+| Model | Input | Output |
+|-------|-------|--------|
+| **Claude Haiku 4.5** | $1.00 | $5.00 |
+| **Claude Sonnet 4.5** | $3.00 | $15.00 |
+| **Claude Opus 4.5** | $5.00 | $25.00 |
+| **GPT-5.1-Codex-Mini** | $0.25 | $2.00 |
+| **GPT-5.1-Codex** | $1.25 | $10.00 |
+| **GPT-5.2-Codex** | $1.75 | $14.00 |
+
+### Cost Analysis
+
+**API pricing favors OpenAI at the low end:** GPT-5.1-Codex-Mini ($0.25/$2.00)
+is 4x cheaper than Claude Haiku ($1.00/$5.00) for input, and 2.5x cheaper for
+output. At the flagship tier, GPT-5.2-Codex ($1.75/$14.00) vs Claude Opus
+($5.00/$25.00) -- OpenAI is ~3x cheaper on input and ~1.8x cheaper on output.
+
+**Subscription pricing favors Claude for heavy use:** Both offer $20/mo Pro
+tiers with Claude Code / Codex access. Claude's Max $200/mo plan gives 20x
+usage, which real-world tests show saves ~18x vs API costs for heavy coding
+(API costs can exceed $3,650/mo for power users). OpenAI's $200/mo Pro tier
+gives 300-1,500 messages/5hrs but limits are message-based, not token-based.
+
+**Hidden costs matter:**
+- Claude Code sends large context windows with every request, making API
+  pricing very expensive for coding workflows
+- OpenAI's reasoning tokens (invisible via API) are billed as output tokens,
+  inflating costs on complex tasks
+- Both offer prompt caching (90% discount on cache hits for OpenAI, 90% for
+  Claude cache reads)
+- Claude offers 50% batch processing discount for non-urgent tasks
+
+**Steinberger's cost profile:** Running 3-8 parallel Codex instances burning
+tokens constantly. At API rates with GPT-5.2-Codex, this would be extremely
+expensive. He likely uses the ChatGPT Pro $200/mo plan, making parallel agents
+cost-effective within message limits.
+
+**Your cost profile:** Single Claude Code agent with structured commands that
+reduce wasted tokens. The Max $200/mo plan is the sweet spot for heavy daily
+use. Your slash commands and skillchain likely produce more focused prompts,
+reducing per-task token consumption vs. conversational back-and-forth.
+
+### Bottom Line on Cost
+
+| Scenario | Cheaper Option | Why |
+|----------|---------------|-----|
+| Light use (API) | GPT Codex Mini | $0.25/1M input vs $1.00 |
+| Heavy use (API) | GPT Codex | ~2-3x cheaper per token at flagship tier |
+| Heavy use (subscription) | Roughly equal | Both ~$200/mo for power users |
+| Parallel agents | GPT Codex (subscription) | Message-based limits suit parallel workflows |
+| Single agent, deep context | Claude Code (subscription) | Token-based limits favor focused, long sessions |
+| Team pricing | GPT Codex | $25-30/seat vs $150/seat for Claude premium |
+
+---
+
+## Summary
+
+Your dotfiles represent a **structured, single-agent, Cloudflare-native**
+workflow with explicit guardrails (slash commands, blueprints, MCPs, testing
+pipeline). Steinberger's setup is a **conversational, multi-agent, multi-platform**
+workflow that prioritizes speed and parallelism over structure.
+
+Neither is objectively better -- they reflect different contexts:
+- **You:** Solo developer shipping Cloudflare apps with consistency and quality
+  gates. One agent, deep context, structured pipeline.
+- **Steinberger:** Solo developer shipping across 5+ surfaces (web, mobile,
+  desktop, extension, CLI) at maximum velocity. Many agents, shallow context,
+  conversational iteration.
+
+On cost: OpenAI is cheaper per-token at every tier, but subscription economics
+roughly equalize at the $200/mo power-user level. Your structured approach likely
+burns fewer tokens per task; his parallel approach burns more but ships faster
+across a wider surface area.

--- a/summaries/dotfiles-comparison-steipete.md
+++ b/summaries/dotfiles-comparison-steipete.md
@@ -35,7 +35,7 @@ what Peter Steinberger describes across his two posts:
 | **Desktop** | None mentioned | Tauri |
 | **Browser ext** | None mentioned | Chrome extension |
 | **Testing** | vitest, testing-library, Playwright | Mentioned but not detailed |
-| **AI agent** | Claude Code (sole agent) | GPT-5 Codex (primary), multi-model |
+| **AI agent** | Claude Code (sole agent) | Multi-model: Claude Code + OpenAI GPT-5/Codex (pragmatic per-task selection) |
 | **Agent instances** | Single agent, sequential workflow | 3-8 parallel instances in tmux grid |
 | **Terminal** | Ghostty | tmux (terminal not specified) |
 | **Shell** | Zsh + Starship | Not detailed |
@@ -54,7 +54,7 @@ what Peter Steinberger describes across his two posts:
 | Practice | Your Approach | Steinberger's Approach |
 |----------|--------------|----------------------|
 | **Agent count** | 1 agent at a time | 3-8 agents in parallel (tmux 3x3 grid) |
-| **Agent model** | Claude Code only | GPT-5 Codex primary, multi-model |
+| **Agent model** | Claude Code only | Multi-model: Claude Code + GPT-5/Codex (best tool per task) |
 | **Prompting style** | Structured slash commands + skillchain roles | Conversational ("just talk to it") |
 | **Planning** | `/plan` command with stack constraints | "Discuss" and "give me options" -- no rigid plan mode |
 | **Task scoping** | GitHub issues via `/issues` command | "Blast radius thinking" -- scope to limit impact |
@@ -68,7 +68,13 @@ what Peter Steinberger describes across his two posts:
 
 ---
 
-## Cost Comparison: Claude Code vs. GPT Codex
+## Cost Comparison: Claude Code vs. OpenAI Codex
+
+> **Note:** OpenAI Codex is OpenAI's cloud-based agentic coding tool (part of
+> ChatGPT). Steinberger uses **both** Claude Code and OpenAI's models -- his
+> `agents.md` symlinked to `claude.md` confirms Claude Code usage, while he
+> credits GPT-5 as a quality unlock and references Codex for cross-project work.
+> He's pragmatically multi-model, not locked to either provider.
 
 ### Subscription Plans
 
@@ -113,10 +119,12 @@ gives 300-1,500 messages/5hrs but limits are message-based, not token-based.
   Claude cache reads)
 - Claude offers 50% batch processing discount for non-urgent tasks
 
-**Steinberger's cost profile:** Running 3-8 parallel Codex instances burning
-tokens constantly. At API rates with GPT-5.2-Codex, this would be extremely
-expensive. He likely uses the ChatGPT Pro $200/mo plan, making parallel agents
-cost-effective within message limits.
+**Steinberger's cost profile:** Running 3-8 parallel agent instances (Claude Code
+and/or OpenAI Codex) burning tokens constantly. He uses a multi-model approach,
+picking the best tool per task and language. At API rates this would be extremely
+expensive across either provider. He likely uses subscription plans for both
+($200/mo Claude Max + $200/mo ChatGPT Pro), making parallel agents cost-effective
+within their respective limits.
 
 **Your cost profile:** Single Claude Code agent with structured commands that
 reduce wasted tokens. The Max $200/mo plan is the sweet spot for heavy daily

--- a/summaries/just-talk-to-it.md
+++ b/summaries/just-talk-to-it.md
@@ -1,0 +1,73 @@
+# Just Talk To It - the no-bs Way of Agentic Engineering
+
+**Author:** Peter Steinberger
+**Source:** https://steipete.me/posts/just-talk-to-it
+
+## Core Thesis
+
+Stop over-engineering your AI workflows. Don't waste time on RAG, subagent
+frameworks, or elaborate orchestration tools. Instead, develop intuition by
+directly conversing with AI agents -- treat them as collaborative partners, not
+complex systems requiring middleware.
+
+## Key Takeaways
+
+### Talk Like a Human
+Drop the "SCREAMING ALL-CAPS" prompt engineering and threatening language.
+Just use natural words. Different models respond differently to tone -- GPT-5
+actively dislikes aggressive prompting, while Claude historically responded to it.
+The best approach is conversational.
+
+### Conversational Over Rigid Plans
+Instead of writing large specs and letting a model build for hours, discuss
+options with the agent interactively. Ask it to "give me options" or "discuss"
+before committing to an approach. Collaborative iteration beats waterfall-style
+prompting.
+
+### Agent Rules Files (CLAUDE.md / Agents.md)
+Steinberger maintains an ~800-line rules file (symlinked as both `agents.md` and
+`claude.md`) that acts as "organizational scar tissue." The agent itself writes
+and maintains these rules -- whenever something goes wrong, it adds a concise
+note to prevent recurrence.
+
+### CLIs Over MCPs
+Most MCP (Model Context Protocol) servers should just be CLIs. When an agent
+runs a CLI and it fails, the help menu lands in context automatically, giving the
+model full usage info. CLIs have no constant context cost unlike MCPs.
+
+### Parallel Agents at Scale
+Run 3-8 agent instances in parallel in a terminal grid (e.g., 3x3 tmux layout),
+most operating in the same folder. This brute-force parallelism gets more done
+than elaborate multi-agent orchestration. tmux handles background persistence.
+
+### Atomic Commits & Clean Git History
+Agents perform git atomic commits themselves, committing exactly the files they
+edited. The rules file is iterated on to enforce clean commit hygiene.
+
+### Blast Radius Thinking
+Scope every task to limit the potential impact of any single agent's changes.
+Think about what could go wrong and contain it.
+
+### 20% Refactoring Cycle
+Dedicate roughly 20% of time to agent-driven refactoring: code duplication
+checks (jscpd), dead code removal (knip), ESLint fixes, API consolidation,
+dependency updates, documentation, and test writing.
+
+### Avoid Over-Engineering
+Tools like Conductor, Terragon, and Sculptor are dismissed as thin wrappers
+around current inefficiencies. They promote workflows that aren't optimal and
+won't survive the next model generation.
+
+## Context
+
+Steinberger works solo on a ~300k LOC TypeScript/React app, a Chrome extension,
+a CLI, a Tauri client app, and an Expo mobile app. Agentic engineering now writes
+"pretty much 100%" of his code. The skills needed to manage agents mirror those
+of senior software engineers -- architecture, system design, and knowing how to
+scope and delegate work.
+
+## Bottom Line
+
+The best agentic engineering framework is no framework. Develop intuition through
+direct interaction. The meta-skill is learning to communicate clearly and scope
+work effectively -- the same skills that make a good engineering manager.

--- a/summaries/shipping-at-inference-speed.md
+++ b/summaries/shipping-at-inference-speed.md
@@ -1,0 +1,72 @@
+# Shipping at Inference Speed
+
+**Author:** Peter Steinberger
+**Source:** https://steipete.me/posts/2025/shipping-at-inference-speed
+**Published:** December 28, 2025
+
+## Core Thesis
+
+"Vibe coding" has evolved from a novelty into a production-grade workflow. The
+bottleneck in software development is no longer writing code -- it's inference
+time and high-level architectural thinking. Most software "shoves data from one
+form to another" and doesn't require hard thinking, so AI agents can handle the
+bulk of it.
+
+## Key Takeaways
+
+### "I Ship Code I Never Read"
+Steinberger confesses that he no longer reads most of the code he ships. He
+watches the stream, occasionally inspects key parts, but trusts the agents to
+produce correct output. The shift from amazement ("some prompts produced code
+that worked") to expectation happened over the course of 2025.
+
+### The GPT-5 Unlock
+The "real unlock" was GPT-5. After a few weeks of use, he started trusting the
+model more and reading less code. The quality jump made it viable to treat AI
+output as production-ready with minimal review.
+
+### Inference Time Is the Bottleneck
+The constraint is no longer developer typing speed or even thinking speed -- it's
+how fast the LLM generates output and how many tokens are spent on deep
+reasoning. The amount of software one person can create is bounded primarily by
+inference time.
+
+### Structure Over Correctness
+Folder layout, module boundaries, and clear responsibilities matter more than
+prompt precision. When the project structure is obvious, agents tend to do the
+right thing. When it's not, no amount of prompting fixes the drift. Architecture
+is the lever.
+
+### Cross-Referencing Projects
+When a problem has already been solved in another project, Steinberger points
+Codex at that folder and lets it infer context. This dramatically reduces
+prompting effort and avoids re-solving solved problems.
+
+### Documentation-Driven Development
+Each project has a `docs/` folder with subsystem and feature documentation. A
+global AGENTS file plus a script forces the model to read relevant docs before
+acting on certain topics. Documentation becomes the guardrail.
+
+### CLI-First Development
+Everything starts as a CLI. Agents can call CLIs directly and verify output,
+closing the feedback loop automatically. This is more reliable than UI-first
+development where validation requires human eyes.
+
+### Multi-Model Workflow
+Different models are used for different tasks and languages (TypeScript, Go,
+Swift). No single model dominates every use case -- the workflow is pragmatically
+multi-model.
+
+## The Factory Model
+
+Development has shifted from artisanal code-writing to a factory-like production
+model. The developer's role is architect, quality controller, and product
+thinker. The agents handle implementation. Speed gains are real but depend
+heavily on project structure and clear architectural boundaries.
+
+## Bottom Line
+
+The speed at which a solo developer can ship is now "unreal" -- bounded by
+inference time rather than human coding speed. The key insight: invest in
+structure, documentation, and CLI-first design. These are what make agents
+reliable. The code itself is increasingly a commodity.

--- a/summaries/steipete-playbook-cc-only.md
+++ b/summaries/steipete-playbook-cc-only.md
@@ -1,0 +1,266 @@
+# Replicating Steinberger's Throughput on Claude Code Max ($200/mo)
+
+Steinberger's speed comes from 10 specific practices. None of them require
+OpenAI. Here's how to replicate each one using only Claude Code Max.
+
+---
+
+## 1. Parallel Agents in Ghostty (not tmux)
+
+Steinberger runs 3-8 agents in a tmux 3x3 grid. You already have Ghostty with
+split keybindings. Use them.
+
+**Setup:**
+```
+# Ghostty splits (already in your config)
+Cmd+Alt+Right    → new split right
+Cmd+Alt+Down     → new split down
+Cmd+Alt+Arrows   → navigate splits
+```
+
+**Workflow:**
+- Open 3-4 Ghostty splits, each running `claude` in the same project
+- Give each agent a different scoped task (see #4 below)
+- Watch all streams simultaneously -- intervene only when one drifts
+
+**Why this works on Max:** The $200/mo plan is token-based, not
+instance-based. Running 4 agents in parallel burns tokens 4x faster but
+finishes 4x sooner. Same total cost, faster wall-clock time.
+
+**Model selection per split:**
+- Use `claude --model sonnet` for routine implementation (cheaper, fast)
+- Use `claude --model opus` for architecture, complex refactors
+- Use `claude --model haiku` for boilerplate, simple file generation
+- This mimics Steinberger's multi-model approach within one provider
+
+---
+
+## 2. Conversational Prompting (Loosen the Pipeline)
+
+Steinberger's core advice: "just talk to it." Your current pipeline
+(`/scaffold` -> `/plan` -> `/issues` -> `/build` -> `/verify`) is great for
+quality but adds ceremony.
+
+**When to use your pipeline:** New features, greenfield projects, anything
+touching architecture.
+
+**When to go conversational:** Bug fixes, small features, refactoring,
+exploration. Skip the slash commands and just talk:
+
+```
+# Instead of:
+/plan
+Here's the spec for adding dark mode...
+
+# Do:
+The settings page needs a dark mode toggle. Give me two options
+for state management -- one using Svelte context, one using a store.
+Let's discuss before coding.
+```
+
+The key phrase is **"give me options"** or **"discuss before coding."** This
+gets you Steinberger's collaborative iteration without abandoning your
+structured approach for big work.
+
+---
+
+## 3. Let the Agent Maintain CLAUDE.md
+
+Steinberger's ~800-line rules file is "organizational scar tissue" -- the agent
+adds rules whenever something goes wrong. You currently hand-maintain yours.
+
+**Adopt this practice:**
+```
+When a mistake happens, tell Claude:
+
+"Add a rule to CLAUDE.md that prevents this from happening again.
+Keep it concise -- one line."
+```
+
+Over time your CLAUDE.md grows organically with hard-won lessons. The rules
+become more precise because they come from real failures, not theoretical best
+practices.
+
+**Guard rail:** Periodically review CLAUDE.md yourself. Prune rules that
+conflict or are no longer relevant. Steinberger's file is ~800 lines -- yours
+should grow but stay curated.
+
+---
+
+## 4. Blast Radius Thinking (Task Scoping)
+
+This is how Steinberger makes parallel agents safe. Each agent gets a task
+scoped to limit what it can break.
+
+**Good scoping for parallel agents:**
+```
+Split 1: "Add the dark mode toggle component in src/lib/components/ThemeToggle.svelte"
+Split 2: "Write unit tests for the theme store in tests/unit/theme.test.ts"
+Split 3: "Update the settings page layout in src/routes/settings/+page.svelte"
+```
+
+**Bad scoping (overlapping blast radius):**
+```
+Split 1: "Add dark mode to the app"
+Split 2: "Refactor the settings page"
+# Both will touch the same files → merge conflicts
+```
+
+**Rule of thumb:** Each parallel agent should touch different files. If two
+tasks might edit the same file, run them sequentially.
+
+---
+
+## 5. Cross-Project Referencing
+
+Steinberger points agents at other project folders to reuse solved patterns.
+Claude Code supports this natively.
+
+**How:**
+```bash
+# Start Claude with access to another project
+claude --add-dir /path/to/other-project
+
+# Or mid-conversation:
+"Look at how /path/to/other-project/src/lib/auth.ts handles session tokens.
+Implement the same pattern here."
+```
+
+This replaces re-explaining solved problems. The agent reads the reference
+implementation and adapts it.
+
+---
+
+## 6. CLI-First Development (Already There)
+
+You're already CLI-first with Wrangler, gh, lazygit, ripgrep, etc. This is one
+of Steinberger's strongest recommendations. Agents can run CLIs, read error
+output, and self-correct. No changes needed.
+
+**One enhancement:** When building new features, consider building the CLI
+interface first, then the UI. Agents can test CLIs autonomously. UIs require
+human eyes (or your `/verify` command).
+
+---
+
+## 7. 20% Refactoring Cycle
+
+Steinberger dedicates ~20% of agent time to code health. You don't have this
+formalized.
+
+**Add to your workflow:**
+
+```bash
+# Install the tools (add to Brewfile)
+pnpm add -Dg jscpd    # code duplication detection
+pnpm add -Dg knip     # dead code / unused exports
+```
+
+**Weekly refactoring prompt:**
+```
+Run these checks and fix what you find:
+1. npx jscpd src/ --min-lines 5 --reporters console
+2. npx knip --no-progress
+3. npx eslint src/ --fix
+4. Check for dependency updates: pnpm outdated
+5. Look for TODO/FIXME/HACK comments and resolve them
+```
+
+This keeps agent-generated code from accumulating debt. Without it, parallel
+agents compound complexity faster than a single agent would.
+
+---
+
+## 8. Structure Over Correctness
+
+Steinberger's strongest insight: folder layout and module boundaries matter more
+than prompt precision. When the project structure is obvious, agents do the
+right thing.
+
+**You already have this** via your `/scaffold` command (SvelteKit conventions,
+`src/lib/components/`, `src/lib/stores/`, etc.). Lean into it harder:
+
+- Enforce consistent naming conventions in CLAUDE.md
+- Add a rule: "Before creating a new file, check if an existing module already
+  handles this concern"
+- Keep `src/lib/` shallow -- agents navigate flat structures better than deep
+  nesting
+
+---
+
+## 9. Ship Code You Don't Fully Read
+
+This is the hardest mindset shift. Steinberger trusts agents and ships without
+reading every line. The safety net is tests + structure, not code review.
+
+**How to get there with your setup:**
+- Your testing pipeline (vitest -> testing-library -> playwright) is already
+  stronger than what Steinberger describes
+- If tests pass and `/verify` shows correct UI, ship it
+- Read code only when: tests fail, behavior is wrong, or you're touching
+  architecture
+- For routine features, watch the stream and intervene only on red flags
+
+**Your advantage:** Your test-before-commit rule is a better safety net than
+Steinberger's "watch the stream" approach. Trust it.
+
+---
+
+## 10. Atomic Agent Commits
+
+Steinberger has agents commit their own work atomically. Your current flow
+requires conventional commits with human review.
+
+**Adapt:**
+```
+Add to CLAUDE.md:
+
+"After completing a self-contained change, commit it immediately with a
+conventional commit message. Don't batch multiple changes into one commit.
+Each commit should be independently revertable."
+```
+
+This pairs well with parallel agents -- each agent commits its own scoped work.
+You review the git log afterward instead of reviewing code in-flight.
+
+---
+
+## Putting It All Together
+
+**Daily workflow on Claude Code Max $200/mo:**
+
+```
+Morning: Open Ghostty, 3-4 splits
+├── Split 1 (opus): Architecture / complex feature
+├── Split 2 (sonnet): Routine implementation
+├── Split 3 (sonnet): Tests for split 1-2's work
+└── Split 4 (haiku): Docs, boilerplate, config changes
+
+Each agent:
+1. Gets a blast-radius-scoped task (different files)
+2. Commits atomically as it works
+3. You watch streams, intervene on drift
+
+Weekly: Run the 20% refactoring cycle across the codebase
+
+Ongoing: When something breaks, tell the agent to add a rule to CLAUDE.md
+```
+
+**What you keep from your current setup:**
+- `/scaffold` for new projects (it's genuinely useful)
+- `/build` for complex features that need TDD discipline
+- `/verify` for UI work
+- CLAUDE.md with stack rules and llms.txt links
+- gitleaks pre-commit hook
+- All your CLI tools
+
+**What you drop or loosen:**
+- Sequential single-agent workflow -> parallel agents
+- Mandatory pipeline for every task -> pipeline for big work, conversation for
+  small work
+- Hand-maintained CLAUDE.md -> agent-maintained with periodic human review
+- Reading all code before shipping -> trust tests, read selectively
+
+**Estimated throughput gain:** 3-4x over single-agent sequential workflow, based
+on parallelism alone. Conversational prompting for small tasks saves additional
+ceremony overhead. All within one $200/mo subscription.


### PR DESCRIPTION
Summarizes key insights from the agentic engineering article covering
conversational prompting, parallel agents, CLI-over-MCP, blast radius
thinking, and the case against over-engineered agent frameworks.

https://claude.ai/code/session_011YEwipDDbEqgkQ38cbdd6D